### PR TITLE
AVFMTCTX_NOHEADER fix

### DIFF
--- a/av/format.pyx
+++ b/av/format.pyx
@@ -79,8 +79,13 @@ cdef class Context(object):
                     break
                     
                 if include_stream[packet.struct.stream_index]:
-                    packet.stream = self.streams[packet.struct.stream_index]
-                    yield packet
+                    # If AVFMTCTX_NOHEADER is set in ctx_flags, then new streams 
+                    # may also appear in av_read_frame().
+                    # http://ffmpeg.org/doxygen/trunk/structAVFormatContext.html
+                    # TODO: find better way to handle this 
+                    if packet.struct.stream_index < len(self.streams):
+                        packet.stream = self.streams[packet.struct.stream_index]
+                        yield packet
 
             # Some codecs will cause frames to be buffered up in the decoding process.
             # These codecs should have a CODEC CAP_DELAY capability set.


### PR DESCRIPTION
I noticed the on some formats, VOB file namely, new streams can appear after a av_read_frame and AVFormatContext.nb_streams will increase. This stops it from raising a exception at least. The docs say AVFMTCTX_NOHEADER is a indicator that this might happen. http://ffmpeg.org/doxygen/trunk/structAVFormatContext.html#a0b748d924898b08b89ff4974afd17285
