### PR TITLE
Use ContextProxy everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,17 @@
 .DS_Store
 /venv
 /vendor
+/bin
+/include
+/lib
+
+# Autoconf.
+/autom4te.cache
+/config.py
+/config.log
+/config.status
+/configure
+>>>>>>> Stream and Codec hold onto ContextProxy
 
 # Build products.
 /build

--- a/av/codec.pyx
+++ b/av/codec.pyx
@@ -16,7 +16,7 @@ cdef class Codec(object):
         self.ctx = stream.ptr.codec
         
         # Keep these pointer alive with this reference.
-        self.format_ctx = stream.ctx.proxy
+        self.format_ctx = stream.ctx
         
         if stream.type == 'attachment':
             return

--- a/av/format.pxd
+++ b/av/format.pxd
@@ -37,7 +37,7 @@ cdef class Stream(object):
     
     cdef readonly bytes type
     
-    cdef Context ctx
+    cdef ContextProxy ctx
     
     cdef lib.AVStream *ptr
     

--- a/av/format.pyx
+++ b/av/format.pyx
@@ -293,8 +293,8 @@ cdef class Stream(object):
         if index < 0 or index > ctx.proxy.ptr.nb_streams:
             raise ValueError('stream index out of range')
         
-        self.ctx = ctx
-        self.ptr = self.ctx.proxy.ptr.streams[index]
+        self.ctx = ctx.proxy
+        self.ptr = self.ctx.ptr.streams[index]
         self.type = type
 
         self.codec = av.codec.Codec(self)

--- a/examples/dealloc.py
+++ b/examples/dealloc.py
@@ -4,7 +4,7 @@ import sys
 import av
 
 path = sys.argv[1] if len(sys.argv) > 1 else 'sandbox/640x360.mp4'
-DELINK = True
+DELINK = False
 
 
 _last_rss = 0


### PR DESCRIPTION
Fix use of `ContextProxy` to remove circular references.

See #14.
