### PR TITLE
FIX: Interpret linesize as absolute value.

### DIFF
--- a/av/video/plane.pyx
+++ b/av/video/plane.pyx
@@ -12,7 +12,8 @@ cdef class VideoPlane(Plane):
         else:
             raise RuntimeError('could not find plane %d of %r' % (index, frame.format))
 
-        self.buffer_size = self.frame.ptr.linesize[self.index] * self.component.height
+        self.buffer_size = (abs(self.frame.ptr.linesize[self.index]) 
+                            * self.component.height)
 
     property width:
         """Pixel width of this plane."""


### PR DESCRIPTION
Closes #39

I don't think this can be fixed on any deeper level, so this is my patch. The packets that raised an error, as described in #39, now open properly.
