### PR TITLE
Mutable `to_ndarray()`

### DIFF
--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -172,10 +172,15 @@ cdef class AudioFrame(Frame):
 
         if self.format.is_planar:
             count = self.samples
-        else:
-            count = self.samples * len(self.layout.channels)
+            return np.vstack([
+                np.frombuffer(x, dtype=dtype, count=count)
+                for x in self.planes
+            ])
 
-        # convert and return data
-        return np.vstack(map(lambda x: np.frombuffer(x, dtype=dtype, count=count), self.planes))
+        else:
+            channels = len(self.layout.channels)
+            count = self.samples * channels
+            return np.frombuffer(self.planes[0], dtype=dtype, count=count).reshape(self.samples, channels)
+
 
     to_nd_array = renamed_attr('to_ndarray')


### PR DESCRIPTION
**Not ready for merging.**

It only works at this time for packed audio, as I'm not 100% on how to wrangle
Cython into doing what I want in the few minutes I have.

I think it is "safe" for us to do this with planar audio as well, assuming that we check that the various `extended_data` pointers have a uniform stride. I think we would need to construct a new object that exposes the buffer API with arbitrary data/size/stride and maintains ownership of the data. Our `Buffer` or something similar could serve that purpose.