### PR TITLE
Add flush method to OutputContainer to force a flush of the buffer

### DIFF
--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -191,6 +191,10 @@ cdef class OutputContainer(Container):
 
         self._done = True
 
+    def flush(self):
+        lib.av_write_frame(self.ptr, NULL)
+        lib.avio_flush(self.ptr.pb)
+
     def mux(self, packets):
         # We accept either a Packet, or a sequence of packets. This should
         # smooth out the transition to the new encode API which returns a

--- a/include/libavformat/avformat.pxd
+++ b/include/libavformat/avformat.pxd
@@ -198,6 +198,10 @@ cdef extern from "libavformat/avformat.h" nogil:
         int flags
     )
 
+    cdef void avio_flush(
+        AVIOContext *,
+    )
+
     cdef int64_t avio_size(
         AVIOContext *s
     )


### PR DESCRIPTION
In some cases it's useful to force a flush of the current output buffer. The code is borrowed from the hlsenc.c 