### PR TITLE
Detect static library and pthread awareness in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,14 @@ _cflag_parser.add_argument('-L', dest='library_dirs', action='append')
 _cflag_parser.add_argument('-l', dest='libraries', action='append')
 _cflag_parser.add_argument('-D', dest='define_macros', action='append')
 _cflag_parser.add_argument('-R', dest='runtime_library_dirs', action='append')
+_cflag_parser.add_argument('-pthread', dest='pthread', action='store_true')
 def parse_cflags(raw_cflags):
     raw_args = shlex.split(raw_cflags.strip())
     args, unknown = _cflag_parser.parse_known_args(raw_args)
     config = {k: v or [] for k, v in args.__dict__.items()}
+    if config.pop('pthread'):
+        config['extra_compile_args'] = ['-pthread']
+        config['extra_link_args'] = ['-pthread']
     for i, x in enumerate(config['define_macros']):
         parts = x.split('=', 1)
         value = x[1] or None if len(x) == 2 else None

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,20 @@ def get_library_config(name):
         print("pkg-config returned flags we don't understand: {}".format(unknown))
         exit(1)
 
+    if not os.environ.get('NO_DETECT_STATIC'):
+        if known['library_dirs']:
+            target = '{}/{}.so'.format(known['library_dirs'][0].rstrip('/'), name)
+            if not os.path.isfile(target):
+                print("static library '{}' is detected".format(name))
+                print("This is probably due to a custom built FFMPEG "\
+                    "was configured without --enable-shared.")
+                print("You may either rebuild you custom FFMPEG with shared "
+                    "enabled, or set env var PKG_CONFIG_PATH to prioritize "
+                    "operating system provided library.")
+                print("If you believe this detection is wrong, you may set "
+                    "env var NO_DETECT_STATIC=1 to bypass it.")
+                exit(1)
+
     return known
 
 

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,9 @@ def get_library_config(name):
 
     if not os.environ.get('NO_DETECT_STATIC'):
         if known['library_dirs']:
-            target = '{}/{}.so'.format(known['library_dirs'][0].rstrip('/'), name)
-            if not os.path.isfile(target):
+            target = known['library_dirs'][0].rstrip('/') + '/' + name
+            if not os.path.isfile(target + '.so') and \
+                    not os.path.isfile(target + '.dylib'):
                 print("static library '{}' is detected".format(name))
                 print("This is probably due to a custom built FFMPEG "\
                     "was configured without --enable-shared.")


### PR DESCRIPTION
It is great to stop trying to build against static ffmpeg library early. But only showing "unknown flags" -pthread is very confusing.
This patch trys to check `'library_dirs'` returned by `parse_cflags`.
If system ffmpeg was used, this should be empty. If a custom built ffmpeg was used, probably in /usr/local/lib, this would be filled by `pkg-config`. And then check if target `.so` file exists there. If it does not exist, the library is probably static. In case this test could go wrong, an env var was added to bypass the test.
I think this should work on linux. I've no idea how this would affect windows or macos users.
I've no idea whether the env var name and error message are proper.