### PR TITLE
added coded_picture_number property to VideoFrame

### DIFF
--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -163,6 +163,10 @@ cdef class VideoFrame(Frame):
         """Is this frame an interlaced or progressive?"""
         def __get__(self): return self.ptr.interlaced_frame
 
+    property coded_picture_number:
+        """picture number in bitstream order"""
+        def __get__(self): return self.ptr.coded_picture_number
+
     @property
     def pict_type(self):
         return PictureType.get(self.ptr.pict_type, create=True)

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -291,6 +291,8 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
 
         int interlaced_frame # 0 or 1.
 
+        int coded_picture_number
+
         int width
         int height
 


### PR DESCRIPTION
Added information about picture number in bitstream order. Some times frames can be in broken order, for example 1, 2, 3...12, 14, 13, 15, 16.... And `coded_picture_number ` possible way to detect it.