### PR TITLE
Improve pixel format handling

### DIFF
--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -157,6 +157,7 @@ cdef class CodecContext(object):
     cdef _init(self, lib.AVCodecContext *ptr, const lib.AVCodec *codec):
 
         self.ptr = ptr
+        self.ptr.opaque = <void*>self
         if self.ptr.codec and codec and self.ptr.codec != codec:
             raise RuntimeError('Wrapping CodecContext with mismatched codec.')
         self.codec = wrap_codec(codec if codec != NULL else self.ptr.codec)

--- a/av/video/codeccontext.pxd
+++ b/av/video/codeccontext.pxd
@@ -10,8 +10,7 @@ cdef class VideoCodecContext(CodecContext):
 
     cdef lib.AVPixelFormat _preferred_format
 
-    cdef VideoFormat _format
-    cdef _build_format(self)
+    cdef VideoFormat _last_format
 
     cdef int last_w
     cdef int last_h

--- a/av/video/codeccontext.pxd
+++ b/av/video/codeccontext.pxd
@@ -1,4 +1,5 @@
 
+cimport libav as lib
 from av.codec.context cimport CodecContext
 from av.video.format cimport VideoFormat
 from av.video.frame cimport VideoFrame
@@ -6,6 +7,8 @@ from av.video.reformatter cimport VideoReformatter
 
 
 cdef class VideoCodecContext(CodecContext):
+
+    cdef lib.AVPixelFormat _preferred_format
 
     cdef VideoFormat _format
     cdef _build_format(self)

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -202,6 +202,7 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         int coded_height
 
         AVPixelFormat pix_fmt
+        AVPixelFormat get_format(AVCodecContext *ctx, const AVPixelFormat *fmt)
         AVRational sample_aspect_ratio
         int gop_size # The number of pictures in a group of pictures, or 0 for intra_only.
         int max_b_frames
@@ -244,6 +245,8 @@ cdef extern from "libavcodec/avcodec.h" nogil:
 
     cdef AVCodecDescriptor* avcodec_descriptor_get (AVCodecID id)
     cdef AVCodecDescriptor* avcodec_descriptor_get_by_name (char *name)
+
+    cdef AVPixelFormat avcodec_default_get_format(AVCodecContext *ctx, const AVPixelFormat *fmt)
 
     cdef char* avcodec_get_name(AVCodecID id)
 

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -51,6 +51,26 @@ class TestCodecContext(TestCase):
         # This one parses into many small packets.
         self._assert_parse('mpeg2video', fate_suite('mpeg2/mpeg2_field_encoding.ts'))
 
+    def test_format_override(self):
+        # Some decoders may override pix_fmt
+        ctx = Codec('gif', 'r').create()
+        ctx.pix_fmt = 'yuv420p'
+        ctx.width = 500
+        ctx.height = 500
+        ctx.open()
+        self.assertNotEqual(ctx.pix_fmt, 'yuv420p')
+
+    def test_format_not_set(self):
+        ctx = Codec('png', 'w').create()
+        self.assertEqual(ctx.format, None)
+        self.assertEqual(ctx.pix_fmt, None)
+        ctx.pix_fmt = 'bgra'
+        self.assertEqual(ctx.format.name, 'bgra')
+        self.assertEqual(ctx.pix_fmt, 'bgra')
+        ctx.pix_fmt = 'invalid'
+        self.assertEqual(ctx.format, None)
+        self.assertEqual(ctx.pix_fmt, None)
+
     def _assert_parse(self, codec_name, path):
 
         fh = av.open(path)


### PR DESCRIPTION
### Allow user to set preferred format

Expose [`get_format`](https://libav.org/documentation/doxygen/master/structAVCodecContext.html#a0d8f46461754e8abea0847dcbc41b956) to allow user to choose decoded pixel format, by adding a `VideoCodecContext.preferred_format` property. If set and supported by the decoder, that format will be used; otherwise fall back to current behaviour.

We could have exposed the callback directly for better control, but since there's `codec.video_formats` and PyAV tries to hide these complexities, I thought it was better this way. WDYT?

### Handle format overrides, not set

The current code only updates `VideoCodecContext.format` and `VideoCodecContext.pix_fmt` when the user modifies them. However, according to the documentation, decoders may override those values too (at open, when decoding frames, etc.). The code now checks for `pix_fmt` / `width` / `height` changes at every access.

Also, when the pixel format is not set, `pix_fmt` now returns None instead of raising.