### PR TITLE
fix double free on extradata source in codec context

### DIFF
--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -231,8 +231,9 @@ cdef class CodecContext(object):
 
         def __set__(self, data):
             self.extradata_source = bytesource(data)
-            self.ptr.extradata = self.extradata_source.ptr
+            self.ptr.extradata = <uint8_t *>malloc(self.extradata_source.length * sizeof(uint8_t))
             self.ptr.extradata_size = self.extradata_source.length
+            memcpy(self.ptr.extradata, self.extradata_source.ptr, self.extradata_source.length)
 
     property extradata_size:
         def __get__(self):

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -167,6 +167,12 @@ class TestEncoding(TestCase):
                    'max_frames': 5}
         self.video_encoding('dnxhd', options)
 
+    def test_codec_context_with_extra_data(self):
+        codec_new = av.codec.Codec("h264", 'r').create()
+        codec_new.open()
+        codec_new.extradata = b"x00"
+        codec_new.close()
+
     def video_encoding(self, codec_name, options={}):
 
         try:


### PR DESCRIPTION
https://github.com/PyAV-Org/PyAV/issues/640#issue-608274450