### PR TITLE
Metadata UnicodeDecodeError Fix

### DIFF
--- a/av/utils.pyx
+++ b/av/utils.pyx
@@ -11,7 +11,12 @@ cimport libav as lib
 # ====================
 
 cdef _decode(char *s, encoding, errors):
-    return (<bytes>s).decode(encoding, errors)
+    try:
+      decoded = (<bytes>s).decode(encoding, errors)
+    except UnicodeDecodeError:
+      print("Ignoring UnicodeDecodeError bytes from : %s" % (str(<bytes>s)))
+      decoded = (<bytes>s).decode(encoding, errors='ignore')
+    return decoded
 
 cdef bytes _encode(s, encoding, errors):
     return s.encode(encoding, errors)

--- a/av/utils.pyx
+++ b/av/utils.pyx
@@ -12,10 +12,10 @@ cimport libav as lib
 
 cdef _decode(char *s, encoding, errors):
     try:
-      decoded = (<bytes>s).decode(encoding, errors)
+        decoded = (<bytes>s).decode(encoding, errors)
     except UnicodeDecodeError:
-      print("Ignoring UnicodeDecodeError bytes from : %s" % (str(<bytes>s)))
-      decoded = (<bytes>s).decode(encoding, errors='ignore')
+        print("Ignoring UnicodeDecodeError bytes from : %s" % (str(<bytes>s)))
+        decoded = (<bytes>s).decode(encoding, errors='ignore')
     return decoded
 
 cdef bytes _encode(s, encoding, errors):


### PR DESCRIPTION
Some movies fail to decode just because of bad metadatas.

``Traceback (most recent call last):``
``File "av\utils.pyx", line 14, in av.utils._decode``
``UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte``

**Examples :**
Ignoring UnicodeDecodeError bytes from : b'AVI-Mux GUI 1.17.8, Aug 30 2008  12:36:58\xff'
-> 'AVI-Mux GUI 1.17.8, Aug 30 2008  12:36:58'

**Proposed solution :**
Merely ignore bad bytes by overriding the errors flag (from 'strict' to 'ignore')
also print the original metadata as a warning