### PR TITLE
[discussion] retrieve rtsp ntp time

### DIFF
--- a/include/libav.pxd
+++ b/include/libav.pxd
@@ -17,6 +17,7 @@ include "libavutil/motion_vector.pxd"
 include "libavcodec/avcodec.pxd"
 include "libavdevice/avdevice.pxd"
 include "libavformat/avformat.pxd"
+include "libavformat/rtsp.pxd"
 include "libswresample/swresample.pxd"
 include "libswscale/swscale.pxd"
 

--- a/include/libavformat/avformat.pxd
+++ b/include/libavformat/avformat.pxd
@@ -174,6 +174,8 @@ cdef extern from "libavformat/avformat.h" nogil:
         AVInputFormat *iformat
         AVOutputFormat *oformat
 
+        void *priv_data
+
         AVIOContext *pb
         AVIOInterruptCB interrupt_callback
 

--- a/include/libavformat/rtsp.pxd
+++ b/include/libavformat/rtsp.pxd
@@ -1,0 +1,14 @@
+from libc.stdint cimport uint32_t, uint64_t
+
+cdef extern from "libavformat/rtsp.h" nogil:
+    ctypedef struct RTSPStream:
+        void *transport_priv
+    
+    ctypedef struct RTSPState:
+        RTSPStream **rtsp_streams
+    
+    ctypedef struct RTPDemuxContext:
+        AVStream *st
+        uint32_t timestamp
+        uint64_t last_rtcp_ntp_time
+        uint32_t last_rtcp_timestamp

--- a/scripts/build-deps
+++ b/scripts/build-deps
@@ -47,8 +47,6 @@ echo ./configure
     --disable-static \
     --disable-stripping \
     --enable-debug=3 \
-    --enable-gpl \
-    --enable-libx264 \
     --enable-shared \
     --prefix="$PYAV_LIBRARY_PREFIX" \
     || exit 2

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ else:
 # The "extras" to be supplied to every one of our modules.
 # This is expanded heavily by the `config` command.
 extension_extra = {
-    'include_dirs': ['include'] + ffmpeg_include,  # The first are PyAV's includes.
+    'include_dirs': ['include', 'vendor/ffmpeg-4.2'] + ffmpeg_include,  # The first are PyAV's includes.
     'libraries'   : [],
     'library_dirs': ffmpeg_lib,
 }
@@ -310,7 +310,6 @@ class ConfigCommand(Command):
             ('no_pkg_config', 'no_pkg_config'),)
 
     def run(self):
-
         # For some reason we get the feeling that CFLAGS is not respected, so we parse
         # it here. TODO: Leave any arguments that we can't figure out.
         for name in 'CFLAGS', 'LDFLAGS':


### PR DESCRIPTION
Hi! 

I have a use case where I would benefit from retrieving the camera's NTP time from a RTSP container. FFMPEG contains structures capable of parsing this information, but unfortunately they are internal and are not available in the public API.

I made this small patch to solve my problem. It is not generic enough, as it hardcodes ntp time into demux return. I also had to include `vendor/ffmpeg-4.2` in include_dirs on setup.py.

My intention with this PR is to share the solution with you and hopely find out a way to change the code so that it can be incorporated into the project.