### PR TITLE
Fix for #689: raise an exception when there is no decoder available

### DIFF
--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -165,6 +165,8 @@ cdef class Stream(object):
 
         .. seealso:: This is mostly a passthrough to :meth:`.CodecContext.decode`.
         """
+        if self.codec_context is None:
+            err_check(lib.AVERROR_DECODER_NOT_FOUND)
         return self.codec_context.decode(packet)
 
     @deprecation.method


### PR DESCRIPTION
Fix crash.