### PR TITLE
[build] pin cibuildwheel to version 1.4.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,7 +229,7 @@ jobs:
           CIBW_TEST_COMMAND_MACOS: true
           CIBW_TEST_REQUIRES: numpy
         run: |
-          pip install cibuildwheel
+          pip install cibuildwheel==1.4.2
           cibuildwheel --output-dir dist
         shell: bash
       - name: Upload wheels

--- a/av/audio/resampler.pyx
+++ b/av/audio/resampler.pyx
@@ -1,5 +1,4 @@
 from libc.stdint cimport int64_t, uint8_t
-
 cimport libav as lib
 
 from av.audio.fifo cimport AudioFifo

--- a/av/buffer.pyx
+++ b/av/buffer.pyx
@@ -1,6 +1,5 @@
+from cpython cimport PyBUF_WRITABLE, PyBuffer_FillInfo
 from libc.string cimport memcpy
-
-from cpython cimport PyBuffer_FillInfo, PyBUF_WRITABLE
 
 from av.bytesource cimport ByteSource, bytesource
 

--- a/av/bytesource.pyx
+++ b/av/bytesource.pyx
@@ -1,4 +1,9 @@
-from cpython.buffer cimport PyObject_CheckBuffer, PyObject_GetBuffer, PyBUF_SIMPLE, PyBuffer_Release
+from cpython.buffer cimport (
+    PyBUF_SIMPLE,
+    PyBuffer_Release,
+    PyObject_CheckBuffer,
+    PyObject_GetBuffer
+)
 
 
 cdef class ByteSource(object):

--- a/av/codec/__init__.py
+++ b/av/codec/__init__.py
@@ -1,3 +1,8 @@
-from .codec import (Capabilities, Codec, Properties, codec_descriptor,
-                    codecs_available)
+from .codec import (
+    Capabilities,
+    Codec,
+    Properties,
+    codec_descriptor,
+    codecs_available
+)
 from .context import CodecContext

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -1,18 +1,18 @@
 from libc.errno cimport EAGAIN
-from libc.stdint cimport uint8_t, int64_t
-from libc.stdlib cimport malloc, realloc, free
+from libc.stdint cimport int64_t, uint8_t
+from libc.stdlib cimport free, malloc, realloc
 from libc.string cimport memcpy
-
 cimport libav as lib
 
 from av.bytesource cimport ByteSource, bytesource
 from av.codec.codec cimport Codec, wrap_codec
 from av.dictionary cimport _Dictionary
-from av.dictionary import Dictionary
 from av.enum cimport define_enum
 from av.error cimport err_check
 from av.packet cimport Packet
 from av.utils cimport avrational_to_fraction, to_avrational
+
+from av.dictionary import Dictionary
 
 
 cdef object _cinit_sentinel = object()

--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -1,6 +1,6 @@
-from libc.stdint cimport int64_t
-from libc.stdlib cimport malloc, free
 from cython.operator cimport dereference
+from libc.stdint cimport int64_t
+from libc.stdlib cimport free, malloc
 
 import os
 import time
@@ -10,13 +10,14 @@ cimport libav as lib
 from av.container.core cimport timeout_info
 from av.container.input cimport InputContainer
 from av.container.output cimport OutputContainer
-from av.container.pyio cimport pyio_read, pyio_write, pyio_seek
+from av.container.pyio cimport pyio_read, pyio_seek, pyio_write
 from av.enum cimport define_enum
 from av.error cimport err_check, stash_exception
 from av.format cimport build_container_format
 
 from av.dictionary import Dictionary
 from av.logging import Capture as LogCapture
+
 
 ctypedef int64_t (*seek_func_t)(void *opaque, int64_t offset, int whence) nogil
 

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -1,5 +1,5 @@
 from libc.stdint cimport int64_t
-from libc.stdlib cimport malloc, free
+from libc.stdlib cimport free, malloc
 
 from av.container.streams cimport StreamContainer
 from av.dictionary cimport _Dictionary

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -1,6 +1,6 @@
 from fractions import Fraction
-import os
 import logging
+import os
 
 from av.codec.codec cimport Codec
 from av.container.streams cimport StreamContainer

--- a/av/container/pyio.pyx
+++ b/av/container/pyio.pyx
@@ -1,5 +1,4 @@
 from libc.string cimport memcpy
-
 cimport libav as lib
 
 from av.container.core cimport Container

--- a/av/enum.pyx
+++ b/av/enum.pyx
@@ -12,6 +12,7 @@ integers for names and values respectively.
 from collections import OrderedDict
 import sys
 
+
 try:
     import copyreg
 except ImportError:

--- a/av/error.pyx
+++ b/av/error.pyx
@@ -2,13 +2,13 @@ cimport libav as lib
 
 from av.logging cimport get_last_error
 
-from av.enum import define_enum
-
 from threading import local
 import errno
 import os
 import sys
 import traceback
+
+from av.enum import define_enum
 
 
 # Will get extended with all of the exceptions.

--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -1,8 +1,8 @@
 from av.utils cimport avrational_to_fraction, to_avrational
 
-from av.sidedata.sidedata import SideDataContainer
-
 from fractions import Fraction
+
+from av.sidedata.sidedata import SideDataContainer
 
 
 cdef class Frame(object):

--- a/av/logging.pyx
+++ b/av/logging.pyx
@@ -32,15 +32,15 @@ API Reference
 
 from __future__ import absolute_import
 
-from libc.stdio cimport printf, fprintf, stderr
-from libc.stdlib cimport malloc, free
-
+from libc.stdio cimport fprintf, printf, stderr
+from libc.stdlib cimport free, malloc
 cimport libav as lib
 
 from threading import Lock
 import logging
 import os
 import sys
+
 
 try:
     from threading import get_ident

--- a/av/sidedata/sidedata.pyx
+++ b/av/sidedata/sidedata.pyx
@@ -2,6 +2,7 @@ from av.enum cimport define_enum
 
 from av.sidedata.motionvectors import MotionVectors
 
+
 try:
     from collections.abc import Mapping
 except ImportError:

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -1,14 +1,17 @@
-from libc.stdint cimport uint8_t, int64_t
-from libc.string cimport memcpy
 from cpython cimport PyWeakref_NewRef
-
+from libc.stdint cimport int64_t, uint8_t
+from libc.string cimport memcpy
 cimport libav as lib
-
 
 from av.codec.context cimport wrap_codec_context
 from av.error cimport err_check
 from av.packet cimport Packet
-from av.utils cimport dict_to_avdict, avdict_to_dict, avrational_to_fraction, to_avrational
+from av.utils cimport (
+    avdict_to_dict,
+    avrational_to_fraction,
+    dict_to_avdict,
+    to_avrational
+)
 
 from av import deprecation
 

--- a/av/utils.pyx
+++ b/av/utils.pyx
@@ -2,9 +2,9 @@ from libc.stdint cimport int64_t, uint8_t, uint64_t
 
 from fractions import Fraction
 
-from av.error cimport err_check
-
 cimport libav as lib
+
+from av.error cimport err_check
 
 
 # === DICTIONARIES ===
@@ -69,4 +69,6 @@ cdef flag_in_bitfield(uint64_t bitfield, uint64_t flag):
 
 
 # === BACKWARDS COMPAT ===
-from .error import FFmpegError as AVError, err_check
+
+from .error import FFmpegError as AVError
+from .error import err_check

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -1,13 +1,12 @@
 from libc.stdint cimport int64_t
-
 cimport libav as lib
 
 from av.codec.context cimport CodecContext
+from av.error cimport err_check
 from av.frame cimport Frame
 from av.packet cimport Packet
 from av.utils cimport avrational_to_fraction, to_avrational
-from av.error cimport err_check
-from av.video.format cimport get_video_format, VideoFormat
+from av.video.format cimport VideoFormat, get_video_format
 from av.video.frame cimport VideoFrame, alloc_video_frame
 from av.video.reformatter cimport VideoReformatter
 

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -1,10 +1,11 @@
 from libc.stdint cimport uint8_t
 
-from av.deprecation import renamed_attr
 from av.enum cimport define_enum
 from av.error cimport err_check
-from av.video.format cimport get_video_format, VideoFormat
+from av.video.format cimport VideoFormat, get_video_format
 from av.video.plane cimport VideoPlane
+
+from av.deprecation import renamed_attr
 
 
 cdef object _cinit_bypass_sentinel

--- a/av/video/reformatter.pyx
+++ b/av/video/reformatter.pyx
@@ -1,5 +1,4 @@
 from libc.stdint cimport uint8_t
-
 cimport libav as lib
 
 from av.enum cimport define_enum

--- a/av/video/stream.pyx
+++ b/av/video/stream.pyx
@@ -1,5 +1,4 @@
 from libc.stdint cimport int64_t
-
 cimport libav as lib
 
 from av.container.core cimport Container

--- a/scripts/fetch-vendor
+++ b/scripts/fetch-vendor
@@ -28,10 +28,6 @@ parser.add_argument("--config-file", default=__file__ + ".json")
 args = parser.parse_args()
 logging.basicConfig(level=logging.INFO)
 
-# work around buggy 'tar' executable on Windows
-if sys.platform == "win32":
-    os.environ["PATH"] = "C:\\Program Files\\Git\\usr\\bin;" + os.environ["PATH"]
-
 # read config file
 with open(args.config_file, "r") as fp:
     config = json.load(fp)

--- a/scripts/fetch-vendor.json
+++ b/scripts/fetch-vendor.json
@@ -1,3 +1,3 @@
 {
-    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/4.2.2-7/ffmpeg-4.2.2-{platform}.tar.bz2"]
+    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/4.3.1-1/ffmpeg-{platform}.tar.gz"]
 }

--- a/scripts/test
+++ b/scripts/test
@@ -25,11 +25,7 @@ fi
 
 if istest isort; then
     # More settings in setup.cfg
-    out="$($PYAV_PYTHON -m isort -q -df -rc av examples tests)"
-    if [[ "$out" ]]; then
-        echo -n "$out"
-        exit 1
-    fi
+    $PYAV_PYTHON -m isort --check-only --diff av examples tests
 fi
 
 if istest main; then

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ skip = av/__init__.py
 known_first_party = av
 default_section = THIRDPARTY
 from_first = 1
+multi_line_output = 3
 
 [metadata]
 license = BSD


### PR DESCRIPTION
Newer cibuildwheel versions seem to fail on Windows.