### PR TITLE
fix docs: loglevel QUIET isn't available

### DIFF
--- a/av/logging.pyx
+++ b/av/logging.pyx
@@ -106,7 +106,7 @@ def set_level(int level):
 
     Sets logging threshold when converting from FFmpeg's logging system
     to Python's. It is recommended to use the constants availible in this
-    module to set the level: ``QUIET``, ``PANIC``, ``FATAL``, ``ERROR``,
+    module to set the level: ``PANIC``, ``FATAL``, ``ERROR``,
     ``WARNING``, ``INFO``, ``VERBOSE``, and ``DEBUG``.
 
     While less efficient, it is generally preferable to modify logging


### PR DESCRIPTION
The documentation lists `QUIET` as a possible loglevel since 64e80ee.
In that same commit, QUIET was marked as `not actually a level`, however.
Later it was fully removed as a loglevel in 2ee9684.

This pull request / commit fixes the documentation in that regard.