### PR TITLE
pkg-config returned flags we don't understand: -pthread -pthread

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ _cflag_parser = argparse.ArgumentParser(add_help=False)
 _cflag_parser.add_argument('-I', dest='include_dirs', action='append')
 _cflag_parser.add_argument('-L', dest='library_dirs', action='append')
 _cflag_parser.add_argument('-l', dest='libraries', action='append')
+_cflag_parser.add_argument('-p', dest='threads', action='append')
 _cflag_parser.add_argument('-D', dest='define_macros', action='append')
 _cflag_parser.add_argument('-R', dest='runtime_library_dirs', action='append')
 def parse_cflags(raw_cflags):


### PR DESCRIPTION
When installing with `pip install av --no-binary av` we get the
error shown above, this change allows setup.py to ignore -pthread

Resolves [bug 720](https://github.com/PyAV-Org/PyAV/issues/720)