### PR TITLE
[tests] do not hardcode errno values

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,3 +1,4 @@
+import errno
 import traceback
 
 import av
@@ -47,7 +48,7 @@ class TestErrorBasics(TestCase):
         try:
             av.open('does not exist')
         except FileNotFoundError as e:
-            self.assertEqual(e.errno, 2)
+            self.assertEqual(e.errno, errno.ENOENT)
             if is_windows:
                 self.assertTrue(e.strerror in ['Error number -2 occurred',
                                                'No such file or directory'])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import errno
 import logging
 import threading
 
@@ -76,7 +77,7 @@ class TestLogging(TestCase):
         log = (av.logging.ERROR, 'test', 'This is a test.')
         av.logging.log(*log)
         try:
-            av.error.err_check(-1)
+            av.error.err_check(-errno.EPERM)
         except OSError as e:
             self.assertEqual(e.log, log)
         else:


### PR DESCRIPTION
Do not assume that `1 == ENOENT` and `2 == EPERM` (as `OSError`); rather use the `errno` module to get/use their values.