### PR TITLE
Use av_guess_format for output container format (fixes: #691)

### DIFF
--- a/av/format.pyx
+++ b/av/format.pyx
@@ -84,7 +84,7 @@ cdef class ContainerFormat(object):
             self.iptr = lib.av_find_input_format(name)
 
         if mode is None or mode == 'w':
-            self.optr = find_output_format(name)
+            self.optr = lib.av_guess_format(name, NULL, NULL)
 
         if not self.iptr and not self.optr:
             raise ValueError('no container format %r' % name)
@@ -170,20 +170,6 @@ cdef class ContainerFormat(object):
     ts_nonstrict = flags.flag_property('TS_NONSTRICT')
     ts_negative = flags.flag_property('TS_NEGATIVE')
     seek_to_pts = flags.flag_property('SEEK_TO_PTS')
-
-
-cdef lib.AVOutputFormat* find_output_format(name):
-    cdef const lib.AVOutputFormat *ptr
-    cdef void *opaque = NULL
-
-    while True:
-        ptr = lib.av_muxer_iterate(&opaque)
-        if not ptr:
-            break
-        if ptr.name == name:
-            return <lib.AVOutputFormat*>ptr
-
-    return NULL
 
 
 cdef get_output_format_names():

--- a/tests/test_containerformat.py
+++ b/tests/test_containerformat.py
@@ -6,15 +6,12 @@ from .common import TestCase
 class TestContainerFormats(TestCase):
 
     def test_matroska(self):
-
         fmt = ContainerFormat('matroska')
-
         self.assertTrue(fmt.is_input)
         self.assertTrue(fmt.is_output)
         self.assertEqual(fmt.name, 'matroska')
         self.assertEqual(fmt.long_name, 'Matroska')
         self.assertIn('mkv', fmt.extensions)
-
         self.assertFalse(fmt.no_file)
 
     def test_mov(self):
@@ -23,6 +20,26 @@ class TestContainerFormats(TestCase):
         self.assertTrue(fmt.is_output)
         self.assertEqual(fmt.name, 'mov')
         self.assertEqual(fmt.long_name, 'QuickTime / MOV')
+        self.assertIn('mov', fmt.extensions)
+        self.assertFalse(fmt.no_file)
+
+    def test_stream_segment(self):
+        # This format goes by two names, check both.
+        fmt = ContainerFormat('stream_segment')
+        self.assertFalse(fmt.is_input)
+        self.assertTrue(fmt.is_output)
+        self.assertEqual(fmt.name, 'stream_segment')
+        self.assertEqual(fmt.long_name, 'streaming segment muxer')
+        self.assertEqual(fmt.extensions, set())
+        self.assertTrue(fmt.no_file)
+
+        fmt = ContainerFormat('ssegment')
+        self.assertFalse(fmt.is_input)
+        self.assertTrue(fmt.is_output)
+        self.assertEqual(fmt.name, 'ssegment')
+        self.assertEqual(fmt.long_name, 'streaming segment muxer')
+        self.assertEqual(fmt.extensions, set())
+        self.assertTrue(fmt.no_file)
 
     def test_formats_available(self):
         self.assertTrue(formats_available)


### PR DESCRIPTION
Some formats go by multiple names, so checking for equality of the
format name fails. Use the higher-level `av_guess_format` which does
the right thing.