### PR TITLE
Fix setting CodecContext.extradata

### DIFF
--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -14,15 +14,15 @@ cdef class CodecContext(object):
     # Whether the AVCodecContext should be de-allocated upon destruction.
     cdef bint allocated
 
+    # Whether AVCodecContext.extradata should be de-allocated upon destruction.
+    cdef bint extradata_set
+
     # Used as a signal that this is within a stream, and also for us to access
     # that stream. This is set "manually" by the stream after constructing
     # this object.
     cdef int stream_index
 
     cdef lib.AVCodecParserContext *parser
-
-    # To hold a reference to passed extradata.
-    cdef ByteSource extradata_source
 
     cdef _init(self, lib.AVCodecContext *ptr, const lib.AVCodec *codec)
 

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -15,6 +15,7 @@ cdef extern from "libavcodec/avcodec.h" nogil:
     cdef char* avcodec_configuration()
     cdef char* avcodec_license()
 
+    cdef size_t AV_INPUT_BUFFER_PADDING_SIZE
     cdef int64_t AV_NOPTS_VALUE
 
     # AVCodecDescriptor.props

--- a/include/libavutil/avutil.pxd
+++ b/include/libavutil/avutil.pxd
@@ -44,6 +44,7 @@ cdef extern from "libavutil/avutil.h" nogil:
 
     cdef void* av_malloc(size_t size)
     cdef void *av_calloc(size_t nmemb, size_t size)
+    cdef void *av_realloc(void *ptr, size_t size)
 
     cdef void av_freep(void *ptr)
 

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -62,6 +62,32 @@ class TestCodecContext(TestCase):
         with av.open(fate_suite('h264/interlaced_crop.mp4')) as container:
             self.assertEqual(container.streams[0].codec_tag, 'avc1')
 
+    def test_decoder_extradata(self):
+        ctx = av.codec.Codec('h264', 'r').create()
+        self.assertEqual(ctx.extradata, None)
+        self.assertEqual(ctx.extradata_size, 0)
+
+        ctx.extradata = b"123"
+        self.assertEqual(ctx.extradata, b"123")
+        self.assertEqual(ctx.extradata_size, 3)
+
+        ctx.extradata = b"54321"
+        self.assertEqual(ctx.extradata, b"54321")
+        self.assertEqual(ctx.extradata_size, 5)
+
+        ctx.extradata = None
+        self.assertEqual(ctx.extradata, None)
+        self.assertEqual(ctx.extradata_size, 0)
+
+    def test_encoder_extradata(self):
+        ctx = av.codec.Codec('h264', 'w').create()
+        self.assertEqual(ctx.extradata, None)
+        self.assertEqual(ctx.extradata_size, 0)
+
+        with self.assertRaises(ValueError) as cm:
+            ctx.extradata = b"123"
+        self.assertEqual(str(cm.exception), "Can only set extradata for decoders.")
+
     def test_parse(self):
 
         # This one parses into a single packet.


### PR DESCRIPTION
- this member can only be set for decoders
- we need to allocate and free the memory