### PR TITLE
Add rgb48 and rgba64 pixel formats

### DIFF
--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -268,9 +268,9 @@ cdef class VideoFrame(Frame):
             return useful_array(frame.planes[0], 3).reshape(frame.height, frame.width, -1)
         elif frame.format.name in ('argb', 'rgba', 'abgr', 'bgra'):
             return useful_array(frame.planes[0], 4).reshape(frame.height, frame.width, -1)
-        elif frame.format.name in ('rgb48le', 'rgb48be'):
+        elif frame.format.name == 'rgb48le':
             return useful_array(frame.planes[0], 6, 'uint16').reshape(frame.height, frame.width, -1)
-        elif frame.format.name in ('rgba64le', 'rgba64be'):
+        elif frame.format.name == 'rgba64le':
             return useful_array(frame.planes[0], 8, 'uint16').reshape(frame.height, frame.width, -1)
         elif frame.format.name in ('gray', 'gray8', 'rgb8', 'bgr8'):
             return useful_array(frame.planes[0]).reshape(frame.height, frame.width)

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -269,9 +269,9 @@ cdef class VideoFrame(Frame):
         elif frame.format.name in ('argb', 'rgba', 'abgr', 'bgra'):
             return useful_array(frame.planes[0], 4).reshape(frame.height, frame.width, -1)
         elif frame.format.name == 'rgb48le':
-            return useful_array(frame.planes[0], 6, 'uint16').reshape(frame.height, frame.width, -1)
+            return useful_array(frame.planes[0], 6, '<u2').reshape(frame.height, frame.width, -1)
         elif frame.format.name == 'rgba64le':
-            return useful_array(frame.planes[0], 8, 'uint16').reshape(frame.height, frame.width, -1)
+            return useful_array(frame.planes[0], 8, '<u2').reshape(frame.height, frame.width, -1)
         elif frame.format.name in ('gray', 'gray8', 'rgb8', 'bgr8'):
             return useful_array(frame.planes[0]).reshape(frame.height, frame.width)
         elif frame.format.name == 'pal8':
@@ -347,14 +347,14 @@ cdef class VideoFrame(Frame):
             assert array.dtype == 'uint8'
             assert array.ndim == 2
         elif format == 'rgb48le':
-            assert array.dtype == 'uint16'
+            assert array.dtype == '<u2'
             assert array.ndim == 3
             assert array.shape[2] == 3
             frame = VideoFrame(array.shape[1], array.shape[0], format)
             copy_array_to_plane(array, frame.planes[0], 6)
             return frame
         elif format == 'rgba64le':
-            assert array.dtype == 'uint16'
+            assert array.dtype == '<u2'
             assert array.ndim == 3
             assert array.shape[2] == 4
             frame = VideoFrame(array.shape[1], array.shape[0], format)

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -260,6 +260,22 @@ class TestVideoFrameNdarray(TestCase):
         self.assertEqual(frame.format.name, 'yuyv422')
         self.assertTrue((frame.to_ndarray() == array).all())
 
+    def test_ndarray_rgb48le(self):
+        array = numpy.random.randint(0, 65536, size=(480, 640, 3), dtype=numpy.uint16)
+        frame = VideoFrame.from_ndarray(array, format='rgb48le')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'rgb48le')
+        self.assertTrue((frame.to_ndarray() == array).all())
+
+    def test_ndarray_rgba64le(self):
+        array = numpy.random.randint(0, 65536, size=(480, 640, 4), dtype=numpy.uint16)
+        frame = VideoFrame.from_ndarray(array, format='rgba64le')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'rgba64le')
+        self.assertTrue((frame.to_ndarray() == array).all())
+
     def test_ndarray_rgb8(self):
         array = numpy.random.randint(0, 256, size=(480, 640), dtype=numpy.uint8)
         frame = VideoFrame.from_ndarray(array, format='rgb8')

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -1,4 +1,5 @@
 from unittest import SkipTest
+import sys
 import warnings
 
 import numpy
@@ -261,7 +262,10 @@ class TestVideoFrameNdarray(TestCase):
         self.assertTrue((frame.to_ndarray() == array).all())
 
     def test_ndarray_rgb48le(self):
-        array = numpy.random.randint(0, 65536, size=(480, 640, 3), dtype=numpy.uint16)
+        array = numpy.random.randint(0, 65536, size=(480, 640, 3), dtype='<u2')
+        if sys.byteorder == 'big' and array.dtype.byteorder == '=':
+            array = array.newbyteorder().byteswap()
+
         frame = VideoFrame.from_ndarray(array, format='rgb48le')
         self.assertEqual(frame.width, 640)
         self.assertEqual(frame.height, 480)
@@ -269,14 +273,65 @@ class TestVideoFrameNdarray(TestCase):
         self.assertEqual(array.dtype, numpy.dtype('<u2'))
         self.assertTrue((frame.to_ndarray() == array).all())
 
+        with self.assertRaises(AssertionError):
+            VideoFrame.from_ndarray(
+                array.newbyteorder(),
+                format='rgb48le'
+            )
+
     def test_ndarray_rgba64le(self):
-        array = numpy.random.randint(0, 65536, size=(480, 640, 4), dtype=numpy.uint16)
+        array = numpy.random.randint(0, 65536, size=(480, 640, 4), dtype='<u2')
+        if sys.byteorder == 'big' and array.dtype.byteorder == '=':
+            array = array.newbyteorder().byteswap()
+
         frame = VideoFrame.from_ndarray(array, format='rgba64le')
         self.assertEqual(frame.width, 640)
         self.assertEqual(frame.height, 480)
         self.assertEqual(frame.format.name, 'rgba64le')
         self.assertEqual(array.dtype, numpy.dtype('<u2'))
         self.assertTrue((frame.to_ndarray() == array).all())
+
+        with self.assertRaises(AssertionError):
+            VideoFrame.from_ndarray(
+                array.newbyteorder(),
+                format='rgba64le'
+            )
+
+    def test_ndarray_rgb48be(self):
+        array = numpy.random.randint(0, 65536, size=(480, 640, 3), dtype='>u2')
+        if sys.byteorder == 'little' and array.dtype.byteorder == '=':
+            array = array.newbyteorder().byteswap()
+
+        frame = VideoFrame.from_ndarray(array, format='rgb48be')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'rgb48be')
+        self.assertEqual(array.dtype.byteorder, '>')
+        self.assertTrue((frame.to_ndarray() == array).all())
+
+        with self.assertRaises(AssertionError):
+            VideoFrame.from_ndarray(
+                array.newbyteorder(),
+                format='rgb48be'
+            )
+
+    def test_ndarray_rgba64be(self):
+        array = numpy.random.randint(0, 65536, size=(480, 640, 4), dtype='>u2')
+        if sys.byteorder == 'little' and array.dtype.byteorder == '=':
+            array = array.newbyteorder().byteswap()
+
+        frame = VideoFrame.from_ndarray(array, format='rgba64be')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'rgba64be')
+        self.assertEqual(array.dtype.byteorder, '>')
+        self.assertTrue((frame.to_ndarray() == array).all())
+
+        with self.assertRaises(AssertionError):
+            VideoFrame.from_ndarray(
+                array.newbyteorder(),
+                format='rgba64be'
+            )
 
     def test_ndarray_rgb8(self):
         array = numpy.random.randint(0, 256, size=(480, 640), dtype=numpy.uint8)

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -266,6 +266,7 @@ class TestVideoFrameNdarray(TestCase):
         self.assertEqual(frame.width, 640)
         self.assertEqual(frame.height, 480)
         self.assertEqual(frame.format.name, 'rgb48le')
+        self.assertEqual(array.dtype, numpy.dtype('<u2'))
         self.assertTrue((frame.to_ndarray() == array).all())
 
     def test_ndarray_rgba64le(self):
@@ -274,6 +275,7 @@ class TestVideoFrameNdarray(TestCase):
         self.assertEqual(frame.width, 640)
         self.assertEqual(frame.height, 480)
         self.assertEqual(frame.format.name, 'rgba64le')
+        self.assertEqual(array.dtype, numpy.dtype('<u2'))
         self.assertTrue((frame.to_ndarray() == array).all())
 
     def test_ndarray_rgb8(self):


### PR DESCRIPTION
Hi!

I was testing out PyAV for a dailies/deliveries tool I'm writing and I noticed there was no support for uint16 data type in the numpy integration. 
With the added pixel types this PR I'm able to create ProRes video files based on 16bit images and maintain image quality.

I only added support for the little endian formats as I know too little on the matter and (_quite selfishly_) I don't know if I need support for big endian..    