### PR TITLE
Rework resampler and fifo to match ffmpeg behavior

### DIFF
--- a/av/audio/codeccontext.pyx
+++ b/av/audio/codeccontext.pyx
@@ -28,30 +28,22 @@ cdef class AudioCodecContext(CodecContext):
 
         cdef AudioFrame frame = input_frame
 
-        # Resample. A None frame will flush the resampler, and then the fifo (if used).
+        cdef bint allow_var_frame_size = self.ptr.codec.capabilities & lib.AV_CODEC_CAP_VARIABLE_FRAME_SIZE
+
         # Note that the resampler will simply return an input frame if there is
         # no resampling to be done. The control flow was just a little easier this way.
         if not self.resampler:
             self.resampler = AudioResampler(
-                self.format,
-                self.layout,
-                self.ptr.sample_rate
+                format=self.format,
+                layout=self.layout,
+                rate=self.ptr.sample_rate,
+                frame_size=None if allow_var_frame_size else self.ptr.frame_size
             )
-        frame = self.resampler.resample(frame)
+        frames = self.resampler.resample(frame)
 
-        cdef bint is_flushing = input_frame is None
-        cdef bint use_fifo = not (self.ptr.codec.capabilities & lib.AV_CODEC_CAP_VARIABLE_FRAME_SIZE)
-
-        if use_fifo:
-            if not self.fifo:
-                self.fifo = AudioFifo()
-            if frame is not None:
-                self.fifo.write(frame)
-            frames = self.fifo.read_many(self.ptr.frame_size, partial=is_flushing)
-            if is_flushing:
-                frames.append(None)
-        else:
-            frames = [frame]
+        # flush if input frame is None
+        if input_frame is None:
+            frames.append(None)
 
         return frames
 

--- a/av/audio/resampler.pxd
+++ b/av/audio/resampler.pxd
@@ -4,6 +4,7 @@ cimport libav as lib
 from av.audio.format cimport AudioFormat
 from av.audio.frame cimport AudioFrame
 from av.audio.layout cimport AudioLayout
+from av.filter.graph cimport Graph
 
 
 cdef class AudioResampler(object):
@@ -14,18 +15,12 @@ cdef class AudioResampler(object):
 
     cdef AudioFrame template
 
-    # Source descriptors; not for public consumption.
-    cdef unsigned int template_rate
-
     # Destination descriptors
     cdef readonly AudioFormat format
     cdef readonly AudioLayout layout
     cdef readonly int rate
+    cdef readonly unsigned int frame_size
 
-    # Retiming.
-    cdef readonly uint64_t samples_in
-    cdef readonly double pts_per_sample_in
-    cdef readonly uint64_t samples_out
-    cdef readonly bint simple_pts_out
+    cdef Graph graph
 
     cpdef resample(self, AudioFrame)

--- a/av/audio/resampler.pyx
+++ b/av/audio/resampler.pyx
@@ -1,13 +1,12 @@
 from libc.stdint cimport int64_t, uint8_t
 cimport libav as lib
 
-from av.audio.fifo cimport AudioFifo
-from av.audio.format cimport get_audio_format
-from av.audio.frame cimport alloc_audio_frame
-from av.audio.layout cimport get_audio_layout
-from av.error cimport err_check
+from av.filter.context cimport FilterContext
+
+import errno
 
 from av.error import FFmpegError
+import av.filter
 
 
 cdef class AudioResampler(object):
@@ -23,17 +22,16 @@ cdef class AudioResampler(object):
 
     """
 
-    def __cinit__(self, format=None, layout=None, rate=None):
+    def __cinit__(self, format=None, layout=None, rate=None, frame_size=None):
         if format is not None:
             self.format = format if isinstance(format, AudioFormat) else AudioFormat(format)
         if layout is not None:
             self.layout = layout if isinstance(layout, AudioLayout) else AudioLayout(layout)
         self.rate = int(rate) if rate else 0
 
-    def __dealloc__(self):
-        if self.ptr:
-            lib.swr_close(self.ptr)
-        lib.swr_free(&self.ptr)
+        self.frame_size = int(frame_size) if frame_size else 0
+
+        self.graph = None
 
     cpdef resample(self, AudioFrame frame):
         """resample(frame)
@@ -42,149 +40,74 @@ cdef class AudioResampler(object):
         a :class:`~.AudioFrame`.
 
         :param AudioFrame frame: The frame to convert.
-        :returns: A new :class:`AudioFrame` in new parameters, or the same frame
-            if there is nothing to be done.
-        :raises: ``ValueError`` if ``Frame.pts`` is set and non-simple.
+        :returns: A list of :class:`AudioFrame` in new parameters. If the nothing is to be done return the same frame
+            as a single element list.
 
         """
-
         if self.is_passthrough:
-            return frame
+            return [frame]
+
+        # We don't have any input, so don't bother even setting up.
+        if not frame:
+            return []
 
         # Take source settings from the first frame.
-        if not self.ptr:
-
-            # We don't have any input, so don't bother even setting up.
-            if not frame:
-                return
-
-            # Hold onto a copy of the attributes of the first frame to populate
-            # output frames with.
-            self.template = alloc_audio_frame()
-            self.template._copy_internal_attributes(frame)
-            self.template._init_user_attributes()
+        if not self.graph:
+            self.template = frame
 
             # Set some default descriptors.
-            self.format = self.format or self.template.format
-            self.layout = self.layout or self.template.layout
-            self.rate = self.rate or self.template.ptr.sample_rate
+            self.format = self.format or frame.format
+            self.layout = self.layout or frame.layout
+            self.rate = self.rate or frame.sample_rate
 
-            # Check if there is actually work to do.
+            # Check if we can passthrough or if there is actually work to do.
             if (
-                self.template.format.sample_fmt == self.format.sample_fmt and
-                self.template.layout.layout == self.layout.layout and
-                self.template.ptr.sample_rate == self.rate
+                frame.format.sample_fmt == self.format.sample_fmt and
+                frame.layout.layout == self.layout.layout and
+                frame.sample_rate == self.rate and
+                self.frame_size == 0
             ):
                 self.is_passthrough = True
-                return frame
+                return [frame]
 
-            # Figure out our time bases.
-            if frame._time_base.num and frame.ptr.sample_rate:
-                self.pts_per_sample_in = frame._time_base.den / float(frame._time_base.num)
-                self.pts_per_sample_in /= self.template.ptr.sample_rate
+            # handle resampling with aformat filter
+            # (similar to configure_output_audio_filter from ffmpeg)
+            self.graph = av.filter.Graph()
+            abuffer = self.graph.add("abuffer",
+                                     sample_rate=str(frame.sample_rate),
+                                     sample_fmt=AudioFormat(frame.format).name,
+                                     channel_layout=frame.layout.name)
+            aformat = self.graph.add("aformat",
+                                     sample_rates=str(self.rate),
+                                     sample_fmts=self.format.name,
+                                     channel_layouts=str(self.layout.layout))
+            abuffersink = self.graph.add("abuffersink")
+            abuffer.link_to(aformat)
+            aformat.link_to(abuffersink)
+            self.graph.configure()
 
-                # We will only provide outgoing PTS if the time_base is trivial.
-                if frame._time_base.num == 1 and frame._time_base.den == frame.ptr.sample_rate:
-                    self.simple_pts_out = True
-
-            self.ptr = lib.swr_alloc()
-            if not self.ptr:
-                raise RuntimeError('Could not allocate SwrContext.')
-
-            # Configure it!
-            try:
-                err_check(lib.av_opt_set_int(self.ptr, 'in_sample_fmt',      <int>self.template.format.sample_fmt, 0))
-                err_check(lib.av_opt_set_int(self.ptr, 'out_sample_fmt',     <int>self.format.sample_fmt, 0))
-                err_check(lib.av_opt_set_int(self.ptr, 'in_channel_layout',  self.template.layout.layout, 0))
-                err_check(lib.av_opt_set_int(self.ptr, 'out_channel_layout', self.layout.layout, 0))
-                err_check(lib.av_opt_set_int(self.ptr, 'in_sample_rate',     self.template.ptr.sample_rate, 0))
-                err_check(lib.av_opt_set_int(self.ptr, 'out_sample_rate',    self.rate, 0))
-                err_check(lib.swr_init(self.ptr))
-            except FFmpegError:
-                self.ptr = NULL
-                raise
+            if self.frame_size > 0:
+                lib.av_buffersink_set_frame_size((<FilterContext>abuffersink).ptr, self.frame_size)
 
         elif frame:
 
             # Assert the settings are the same on consecutive frames.
             if (
-                frame.ptr.format != self.template.format.sample_fmt or
-                frame.ptr.channel_layout != self.template.layout.layout or
-                frame.ptr.sample_rate != self.template.ptr.sample_rate
+                frame.format.sample_fmt != self.template.format.sample_fmt or
+                frame.layout.layout != self.template.layout.layout or
+                frame.sample_rate != self.template.rate
             ):
                 raise ValueError('Frame does not match AudioResampler setup.')
 
-        # Assert that the PTS are what we expect.
-        cdef int64_t expected_pts
-        if frame is not None and frame.ptr.pts != lib.AV_NOPTS_VALUE:
-            expected_pts = <int64_t>(self.pts_per_sample_in * self.samples_in)
-            if frame.ptr.pts != expected_pts:
-                raise ValueError('Input frame pts %d != expected %d; fix or set to None.' % (frame.ptr.pts, expected_pts))
-            self.samples_in += frame.ptr.nb_samples
+        self.graph.push(frame)
 
-        # The example "loop" as given in the FFmpeg documentation looks like:
-        # uint8_t **input;
-        # int in_samples;
-        # while (get_input(&input, &in_samples)) {
-        #     uint8_t *output;
-        #     int out_samples = av_rescale_rnd(swr_get_delay(swr, 48000) +
-        #                                      in_samples, 44100, 48000, AV_ROUND_UP);
-        #     av_samples_alloc(&output, NULL, 2, out_samples,
-        #                      AV_SAMPLE_FMT_S16, 0);
-        #     out_samples = swr_convert(swr, &output, out_samples,
-        #                                      input, in_samples);
-        #     handle_output(output, out_samples);
-        #     av_freep(&output);
-        # }
-
-        # Estimate out how many samples this will create; it will be high.
-        # My investigations say that this swr_get_delay is not required, but
-        # it is in the example loop, and avresample (as opposed to swresample)
-        # may require it.
-        cdef int output_nb_samples = lib.av_rescale_rnd(
-            lib.swr_get_delay(self.ptr, self.rate) + frame.ptr.nb_samples,
-            self.rate,
-            self.template.ptr.sample_rate,
-            lib.AV_ROUND_UP,
-        ) if frame else lib.swr_get_delay(self.ptr, self.rate)
-
-        # There aren't any frames coming, so no new frame pops out.
-        if not output_nb_samples:
-            return
-
-        cdef AudioFrame output = alloc_audio_frame()
-        output._copy_internal_attributes(self.template)
-        output.ptr.sample_rate = self.rate
-        output._init(
-            self.format.sample_fmt,
-            self.layout.layout,
-            output_nb_samples,
-            1,  # Align?
-        )
-
-        output.ptr.nb_samples = err_check(lib.swr_convert(
-            self.ptr,
-            output.ptr.extended_data,
-            output_nb_samples,
-            # Cast for const-ness, because Cython isn't expressive enough.
-            <const uint8_t**>(frame.ptr.extended_data if frame else NULL),
-            frame.ptr.nb_samples if frame else 0
-        ))
-
-        # Empty frame.
-        if output.ptr.nb_samples <= 0:
-            return
-
-        # Create new PTSes in simple cases.
-        if self.simple_pts_out:
-            output._time_base.num = 1
-            output._time_base.den = self.rate
-            output.ptr.pts = self.samples_out
-        else:
-            output._time_base.num = 0
-            output._time_base.den = 1
-            output.ptr.pts = lib.AV_NOPTS_VALUE
-
-        self.samples_out += output.ptr.nb_samples
+        output = []
+        while True:
+            try:
+                output.append(self.graph.pull())
+            except av.utils.AVError as e:
+                if e.errno != errno.EAGAIN:
+                    raise
+                break
 
         return output

--- a/include/libavfilter/avfilter.pxd
+++ b/include/libavfilter/avfilter.pxd
@@ -75,3 +75,7 @@ cdef extern from "libavfilter/avfilter.h" nogil:
 
     # custom
     cdef set pyav_get_available_filters()
+
+
+cdef extern from "libavfilter/buffersink.h" nogil:
+    cdef void av_buffersink_set_frame_size(AVFilterContext *ctx, unsigned frame_size)

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -376,18 +376,15 @@ class TestEncoding(TestCase):
                     next(encoder.encode(bad_frame))
                 """
 
-                resampled_frame = resampler.resample(frame)
-                samples += resampled_frame.samples
+                resampled_frames = resampler.resample(frame)
+                for resampled_frame in resampled_frames:
+                    samples += resampled_frame.samples
 
-                for packet in ctx.encode(resampled_frame):
-                    # bytearray because python can
-                    # freaks out if the first byte is NULL
-                    f.write(bytearray(packet))
-                    packet_sizes.append(packet.size)
-
-            for packet in ctx.encode(None):
-                packet_sizes.append(packet.size)
-                f.write(bytearray(packet))
+                    for packet in ctx.encode(resampled_frame):
+                        # bytearray because python can
+                        # freaks out if the first byte is NULL
+                        f.write(bytearray(packet))
+                        packet_sizes.append(packet.size)
 
         ctx = Codec(codec_name, 'r').create()
         ctx.time_base = Fraction(1) / sample_rate

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -199,7 +199,12 @@ class TestEncodeStreamSemantics(TestCase):
         self.assertEqual(vpacket.stream_index, 0)
 
         for i in range(10):
-            aframe = AudioFrame('s16', 'stereo', samples=astream.frame_size)
+            if astream.frame_size != 0:
+                frame_size = astream.frame_size
+            else:
+                # decoder didn't indicate constant frame size
+                frame_size = 1000
+            aframe = AudioFrame('s16', 'stereo', samples=frame_size)
             aframe.rate = 48000
             apackets = astream.encode(aframe)
             if apackets:


### PR DESCRIPTION
The pyav resampler and the fifo can't handle any pts inconsistencies, but ffmpeg can. If we take a look at the ffmpeg tool we can see that the heavy lifting for the resampling is done by the aformat filter (https://github.com/FFmpeg/FFmpeg/blob/169259d9a381a3c2132672da5c5f250fa194fb4d/fftools/ffmpeg_filter.c#L607). The fifo is implemented by the the buffersink (https://github.com/FFmpeg/FFmpeg/blob/169259d9a381a3c2132672da5c5f250fa194fb4d/fftools/ffmpeg_filter.c#L1113).

This PR to matches the pyav resampler behavior to the ffmpeg tool by using the same filters. This also simplifies the code quite a bit. 

Fixes #761
Depends on #765