### PR TITLE
Reflect the updated FFMPEG version in docs

### DIFF
--- a/docs/overview/about.rst
+++ b/docs/overview/about.rst
@@ -4,7 +4,7 @@ More About PyAV
 Binary wheels
 -------------
 
-Since release 8.0.0 binary wheels are provided on PyPI for Linux, Mac and Windows linked against FFmpeg. Currently FFmpeg 4.2.2 is used with the following features enabled for all platforms:
+Since release 8.0.0 binary wheels are provided on PyPI for Linux, Mac and Windows linked against FFmpeg. Currently FFmpeg 4.3.2 is used with the following features enabled for all platforms:
 
 - fontconfig
 - libaom


### PR DESCRIPTION
PyAV v8.0.3 ships with FFMPEG 4.3.1, which should be reflected in the documentation.