### PR TITLE
Expose AVCodecContext stats_in/stats_out fields as properties

### DIFF
--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -17,6 +17,9 @@ cdef class CodecContext(object):
     # Whether AVCodecContext.extradata should be de-allocated upon destruction.
     cdef bint extradata_set
 
+    # Whether AVCodecContext.stats_in should be de-allocated upon destruction.
+    cdef bint stats_in_set
+
     # Used as a signal that this is within a stream, and also for us to access
     # that stream. This is set "manually" by the stream after constructing
     # this object.

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -249,6 +249,20 @@ cdef class CodecContext(object):
             return self.ptr.extradata_size
 
     property stats_out:
+        """When two-pass encoding is enabled, video encoders (except libx264,
+           see below) will write the stats that they produce in the first
+           encoding pass to this property. The property's contents should be
+           copied over to the :attr:`.stats_in` property of the
+           encoding context used in the second encode pass.
+
+           For libx264, stats are saved to files, so instead of using the
+           :attr:`.stats_out`/:attr:`.stats_in` properties, set
+           :attr:`options["stats"] <.options>` to the desired output file
+           prefix (similarly to how the "-passlogfile" ffmpeg command line
+           option would be used).
+
+        """
+
         def __get__(self):
             if not self.is_encoder:
                 raise ValueError("Can only get stats_out for encoders")
@@ -259,6 +273,11 @@ cdef class CodecContext(object):
                 return (<bytes>self.ptr.stats_out).decode("utf-8")
 
     property stats_in:
+        """Stats used for two-pass encoding. See :attr:`.stats_out`
+        for more details.
+
+        """
+
         def __get__(self):
             if not self.is_encoder:
                 raise ValueError("Can only get stats_in for encoders")

--- a/docs/api/codec.rst
+++ b/docs/api/codec.rst
@@ -92,6 +92,9 @@ Attributes
 .. autoattribute:: CodecContext.extradata
 .. autoattribute:: CodecContext.extradata_size
 
+.. autoattribute:: CodecContext.stats_out
+.. autoattribute:: CodecContext.stats_in
+
 Transcoding
 ~~~~~~~~~~~
 .. automethod:: CodecContext.parse

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -222,6 +222,10 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         # User Data
         void *opaque
 
+        # Two-pass encoding stats
+        char *stats_out
+        char *stats_in
+
     cdef AVCodecContext* avcodec_alloc_context3(AVCodec *codec)
     cdef void avcodec_free_context(AVCodecContext **ctx)
 


### PR DESCRIPTION
This enables two-pass encoding with codecs other than libx264.
The existing "stats" option only works specifically for libx264, which
writes/reads stats from an external file itself. For all other codecs, the
"stats_in"/"stats_out" properties must be used.

The ffmpeg binary contains custom logic for non-libx264 encodes to
write/read the contents of these properties to/from local file. When
using PyAV though, one can simply read the "stats_out" field into memory
after the first pass and then use it to set the "stats_in" property
before starting the second pass, so no external file is needed.

(I believe this should also fix issue #277.)