### PR TITLE
Require Python <3.12 because dependency with distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -516,6 +516,8 @@ setup(
         ],
     },
 
+    python_requires='<3.12',
+
     classifiers=[
        'Development Status :: 5 - Production/Stable',
        'Intended Audience :: Developers',


### PR DESCRIPTION
The distutils module is being removed in Python 3.12[^1] 

This patch marks PyAv as only able to install Python versions less than 3.12 in setup.py. This allows pip to know if this version of av is installable with the Python version and act accordingly.  

### Alternate Approaches 

I've also tried ripping out distutils altogether. However, there is so much code that PyAv relies on that removing distutils would be to big of a change to do all at once. I recommend moving away from using the distutils module in setup.py

[^1]: https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated