### PR TITLE
Do not set max_analyze_duration at container init (fixes #801)

### DIFF
--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -165,7 +165,6 @@ cdef class Container(object):
                 self.ptr.interrupt_callback.opaque = &self.interrupt_callback_info
 
         self.ptr.flags |= lib.AVFMT_FLAG_GENPTS
-        self.ptr.max_analyze_duration = 10000000
 
         # Setup Python IO.
         if self.file is not None:


### PR DESCRIPTION
libavformat seems to set its own default values, see:

https://github.com/FFmpeg/FFmpeg/blob/8ff3fbf6bca0ee897e458fc27e5f967cdcbc16c7/libavformat/demux.c#L2393