### PR TITLE
Harden pix_fmt

### DIFF
--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -6,7 +6,7 @@ from av.error cimport err_check
 from av.frame cimport Frame
 from av.packet cimport Packet
 from av.utils cimport avrational_to_fraction, to_avrational
-from av.video.format cimport VideoFormat, get_video_format
+from av.video.format cimport VideoFormat, get_pix_fmt, get_video_format
 from av.video.frame cimport VideoFrame, alloc_video_frame
 from av.video.reformatter cimport VideoReformatter
 
@@ -93,13 +93,17 @@ cdef class VideoCodecContext(CodecContext):
             self.ptr.height = value
             self._build_format()
 
-    # TODO: Replace with `format`.
     property pix_fmt:
+        """
+        The pixel format's name.
+
+        :type: str
+        """
         def __get__(self):
             return self._format.name
 
         def __set__(self, value):
-            self.ptr.pix_fmt = lib.av_get_pix_fmt(value)
+            self.ptr.pix_fmt = get_pix_fmt(value)
             self._build_format()
 
     property framerate:

--- a/av/video/format.pxd
+++ b/av/video/format.pxd
@@ -23,3 +23,5 @@ cdef class VideoFormatComponent(object):
 
 
 cdef VideoFormat get_video_format(lib.AVPixelFormat c_format, unsigned int width, unsigned int height)
+
+cdef lib.AVPixelFormat get_pix_fmt(const char *name) except lib.AV_PIX_FMT_NONE

--- a/av/video/format.pyx
+++ b/av/video/format.pyx
@@ -8,6 +8,16 @@ cdef VideoFormat get_video_format(lib.AVPixelFormat c_format, unsigned int width
     format._init(c_format, width, height)
     return format
 
+cdef lib.AVPixelFormat get_pix_fmt(const char *name) except lib.AV_PIX_FMT_NONE:
+    """Wrapper for lib.av_get_pix_fmt with error checking."""
+
+    cdef lib.AVPixelFormat pix_fmt = lib.av_get_pix_fmt(name)
+
+    if pix_fmt == lib.AV_PIX_FMT_NONE:
+        raise ValueError('not a pixel format: %r' % name)
+
+    return pix_fmt
+
 
 cdef class VideoFormat(object):
     """
@@ -29,9 +39,7 @@ cdef class VideoFormat(object):
             self._init(other.pix_fmt, width or other.width, height or other.height)
             return
 
-        cdef lib.AVPixelFormat pix_fmt = lib.av_get_pix_fmt(name)
-        if pix_fmt < 0:
-            raise ValueError('not a pixel format: %r' % name)
+        cdef lib.AVPixelFormat pix_fmt = get_pix_fmt(name)
         self._init(pix_fmt, width, height)
 
     cdef _init(self, lib.AVPixelFormat pix_fmt, unsigned int width, unsigned int height):

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -2,7 +2,7 @@ from libc.stdint cimport uint8_t
 
 from av.enum cimport define_enum
 from av.error cimport err_check
-from av.video.format cimport VideoFormat, get_video_format
+from av.video.format cimport VideoFormat, get_pix_fmt, get_video_format
 from av.video.plane cimport VideoPlane
 
 from av.deprecation import renamed_attr
@@ -71,9 +71,7 @@ cdef class VideoFrame(Frame):
         if width is _cinit_bypass_sentinel:
             return
 
-        cdef lib.AVPixelFormat c_format = lib.av_get_pix_fmt(format)
-        if c_format < 0:
-            raise ValueError('invalid format %r' % format)
+        cdef lib.AVPixelFormat c_format = get_pix_fmt(format)
 
         self._init(c_format, width, height)
 

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -88,6 +88,19 @@ class TestCodecContext(TestCase):
             ctx.extradata = b"123"
         self.assertEqual(str(cm.exception), "Can only set extradata for decoders.")
 
+    def test_encoder_pix_fmt(self):
+        ctx = av.codec.Codec('h264', 'w').create()
+
+        # valid format
+        ctx.pix_fmt = "yuv420p"
+        self.assertEqual(ctx.pix_fmt, "yuv420p")
+
+        # invalid format
+        with self.assertRaises(ValueError) as cm:
+            ctx.pix_fmt = "__unknown_pix_fmt"
+        self.assertEqual(str(cm.exception), "not a pixel format: '__unknown_pix_fmt'")
+        self.assertEqual(ctx.pix_fmt, "yuv420p")
+
     def test_parse(self):
 
         # This one parses into a single packet.

--- a/tests/test_videoformat.py
+++ b/tests/test_videoformat.py
@@ -4,6 +4,10 @@ from .common import TestCase
 
 
 class TestVideoFormats(TestCase):
+    def test_invalid_pixel_format(self):
+        with self.assertRaises(ValueError) as cm:
+            VideoFormat("__unknown_pix_fmt", 640, 480)
+        self.assertEqual(str(cm.exception), "not a pixel format: '__unknown_pix_fmt'")
 
     def test_rgb24_inspection(self):
         fmt = VideoFormat('rgb24', 640, 480)

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -10,6 +10,10 @@ from .common import Image, TestCase, fate_png
 
 
 class TestVideoFrameConstructors(TestCase):
+    def test_invalid_pixel_format(self):
+        with self.assertRaises(ValueError) as cm:
+            VideoFrame(640, 480, "__unknown_pix_fmt")
+        self.assertEqual(str(cm.exception), "not a pixel format: '__unknown_pix_fmt'")
 
     def test_null_constructor(self):
         frame = VideoFrame()


### PR DESCRIPTION
Fixes #815.

I implemented a `get_pix_fmt` wrapper that calls and checks the return value of `av_get_pix_fmt` and raises an appropriate exception.