### PR TITLE
Fix setting Stream time_base (fixes #784)

### DIFF
--- a/av/stream.pxd
+++ b/av/stream.pxd
@@ -24,6 +24,8 @@ cdef class Stream(object):
     # Private API.
     cdef _init(self, Container, lib.AVStream*)
     cdef _finalize_for_output(self)
+    cdef _set_time_base(self, value)
+    cdef _set_id(self, value)
 
 
 cdef Stream wrap_stream(Container, lib.AVStream*)

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -127,6 +127,8 @@ cdef class Stream(object):
 
     def __setattr__(self, name, value):
         setattr(self.codec_context, name, value)
+        if name == "time_base":
+            to_avrational(value, &self._stream.time_base)
 
     cdef _finalize_for_output(self):
 
@@ -228,9 +230,6 @@ cdef class Stream(object):
         """
         def __get__(self):
             return avrational_to_fraction(&self._stream.time_base)
-
-        def __set__(self, value):
-            to_avrational(value, &self._stream.time_base)
 
     property average_rate:
         """

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -126,9 +126,12 @@ cdef class Stream(object):
                 raise AttributeError(name)
 
     def __setattr__(self, name, value):
+        if name == "id":
+            self._set_id(value)
+            return
         setattr(self.codec_context, name, value)
         if name == "time_base":
-            to_avrational(value, &self._stream.time_base)
+            self._set_time_base(value)
 
     cdef _finalize_for_output(self):
 
@@ -195,11 +198,14 @@ cdef class Stream(object):
         def __get__(self):
             return self._stream.id
 
-        def __set__(self, v):
-            if v is None:
-                self._stream.id = 0
-            else:
-                self._stream.id = v
+    def _set_id(self, value):
+        """
+        Setter used by __setattr__ for id property.
+        """
+        if value is None:
+            self._stream.id = 0
+        else:
+            self._stream.id = value
 
     property profile:
         """
@@ -230,6 +236,12 @@ cdef class Stream(object):
         """
         def __get__(self):
             return avrational_to_fraction(&self._stream.time_base)
+
+    def _set_time_base(self, value):
+        """
+        Setter used by __setattr__ for time_base property.
+        """
+        to_avrational(value, &self._stream.time_base)
 
     property average_rate:
         """

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -200,7 +200,7 @@ cdef class Stream(object):
 
     def _set_id(self, value):
         """
-        Setter used by __setattr__ for id property.
+        Setter used by __setattr__ for the id property.
         """
         if value is None:
             self._stream.id = 0
@@ -239,7 +239,7 @@ cdef class Stream(object):
 
     def _set_time_base(self, value):
         """
-        Setter used by __setattr__ for time_base property.
+        Setter used by __setattr__ for the time_base property.
         """
         to_avrational(value, &self._stream.time_base)
 

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -198,7 +198,7 @@ cdef class Stream(object):
         def __get__(self):
             return self._stream.id
 
-    def _set_id(self, value):
+    cdef _set_id(self, value):
         """
         Setter used by __setattr__ for the id property.
         """
@@ -237,7 +237,7 @@ cdef class Stream(object):
         def __get__(self):
             return avrational_to_fraction(&self._stream.time_base)
 
-    def _set_time_base(self, value):
+    cdef _set_time_base(self, value):
         """
         Setter used by __setattr__ for the time_base property.
         """

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -208,3 +208,12 @@ class TestEncodeStreamSemantics(TestCase):
 
         self.assertIs(apacket.stream, astream)
         self.assertEqual(apacket.stream_index, 1)
+
+    def test_audio_set_time_base(self):
+        output = av.open(self.sandboxed('output.mov'), 'w')
+
+        stream = output.add_stream('mp2')
+        self.assertEqual(stream.rate, 48000)
+        stream.time_base = Fraction(1, 48000)
+        self.assertEqual(stream.time_base, None)
+        self.assertEqual(stream.time_base, Fraction(1, 48000))

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -214,6 +214,6 @@ class TestEncodeStreamSemantics(TestCase):
 
         stream = output.add_stream('mp2')
         self.assertEqual(stream.rate, 48000)
-        stream.time_base = Fraction(1, 48000)
         self.assertEqual(stream.time_base, None)
+        stream.time_base = Fraction(1, 48000)
         self.assertEqual(stream.time_base, Fraction(1, 48000))

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -209,7 +209,7 @@ class TestEncodeStreamSemantics(TestCase):
         self.assertIs(apacket.stream, astream)
         self.assertEqual(apacket.stream_index, 1)
 
-    def test_audio_set_time_base(self):
+    def test_audio_set_time_base_and_id(self):
         output = av.open(self.sandboxed('output.mov'), 'w')
 
         stream = output.add_stream('mp2')
@@ -217,3 +217,6 @@ class TestEncodeStreamSemantics(TestCase):
         self.assertEqual(stream.time_base, None)
         stream.time_base = Fraction(1, 48000)
         self.assertEqual(stream.time_base, Fraction(1, 48000))
+        self.assertEqual(stream.id, 0)
+        stream.id = 1
+        self.assertEqual(stream.id, 1)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -217,4 +217,3 @@ class TestEncodeStreamSemantics(TestCase):
         self.assertEqual(stream.time_base, None)
         stream.time_base = Fraction(1, 48000)
         self.assertEqual(stream.time_base, Fraction(1, 48000))
-        

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -217,3 +217,4 @@ class TestEncodeStreamSemantics(TestCase):
         self.assertEqual(stream.time_base, None)
         stream.time_base = Fraction(1, 48000)
         self.assertEqual(stream.time_base, Fraction(1, 48000))
+        


### PR DESCRIPTION
In contrast to `__getattr__`, `__setattr__` [doesn't check the existing attributes](https://docs.python.org/3/reference/datamodel.html#object.__getattr__) first. This causes the `Stream.time_base` setter to never get called. This PR moves the `Stream.time_base` setter into `Stream.__setattr__`, and this should fix #784.