### PR TITLE
Replace deprecated av_init_packet with av_packet_alloc

### DIFF
--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -376,7 +376,7 @@ cdef class CodecContext(object):
                 # ... but this results in corruption.
 
                 packet = Packet(out_size)
-                memcpy(packet.struct.data, out_data, out_size)
+                memcpy(packet.ptr.data, out_data, out_size)
 
                 packets.append(packet)
 
@@ -417,7 +417,7 @@ cdef class CodecContext(object):
 
         cdef int res
         with nogil:
-            res = lib.avcodec_send_packet(self.ptr, &packet.struct if packet is not None else NULL)
+            res = lib.avcodec_send_packet(self.ptr, packet.ptr if packet is not None else NULL)
         err_check(res)
 
         out = []
@@ -459,7 +459,7 @@ cdef class CodecContext(object):
 
         cdef int res
         with nogil:
-            res = lib.avcodec_receive_packet(self.ptr, &packet.struct)
+            res = lib.avcodec_receive_packet(self.ptr, packet.ptr)
         if res == -EAGAIN or res == lib.AVERROR_EOF:
             return
         err_check(res)

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -138,18 +138,18 @@ cdef class InputContainer(Container):
                 try:
                     self.start_timeout()
                     with nogil:
-                        ret = lib.av_read_frame(self.ptr, &packet.struct)
+                        ret = lib.av_read_frame(self.ptr, packet.ptr)
                     self.err_check(ret)
                 except EOFError:
                     break
 
-                if include_stream[packet.struct.stream_index]:
+                if include_stream[packet.ptr.stream_index]:
                     # If AVFMTCTX_NOHEADER is set in ctx_flags, then new streams
                     # may also appear in av_read_frame().
                     # http://ffmpeg.org/doxygen/trunk/structAVFormatContext.html
                     # TODO: find better way to handle this
-                    if packet.struct.stream_index < len(self.streams):
-                        packet._stream = self.streams[packet.struct.stream_index]
+                    if packet.ptr.stream_index < len(self.streams):
+                        packet._stream = self.streams[packet.ptr.stream_index]
                         # Keep track of this so that remuxing is easier.
                         packet._time_base = packet._stream._stream.time_base
                         yield packet

--- a/av/packet.pxd
+++ b/av/packet.pxd
@@ -7,7 +7,7 @@ from av.stream cimport Stream
 
 cdef class Packet(Buffer):
 
-    cdef lib.AVPacket struct
+    cdef lib.AVPacket* ptr
 
     cdef Stream _stream
 

--- a/av/packet.pyx
+++ b/av/packet.pyx
@@ -18,7 +18,7 @@ cdef class Packet(Buffer):
 
     def __cinit__(self, input=None):
         with nogil:
-            lib.av_init_packet(&self.struct)
+            self.ptr = lib.av_packet_alloc()
 
     def __init__(self, input=None):
 
@@ -35,7 +35,7 @@ cdef class Packet(Buffer):
             size = source.length
 
         if size:
-            err_check(lib.av_new_packet(&self.struct, size))
+            err_check(lib.av_new_packet(self.ptr, size))
 
         if source is not None:
             self.update(source)
@@ -45,7 +45,7 @@ cdef class Packet(Buffer):
 
     def __dealloc__(self):
         with nogil:
-            lib.av_packet_unref(&self.struct)
+            lib.av_packet_free(&self.ptr)
 
     def __repr__(self):
         return '<av.%s of #%d, dts=%s, pts=%s; %s bytes at 0x%x>' % (
@@ -53,15 +53,15 @@ cdef class Packet(Buffer):
             self._stream.index if self._stream else 0,
             self.dts,
             self.pts,
-            self.struct.size,
+            self.ptr.size,
             id(self),
         )
 
     # Buffer protocol.
     cdef size_t _buffer_size(self):
-        return self.struct.size
+        return self.ptr.size
     cdef void* _buffer_ptr(self):
-        return self.struct.data
+        return self.ptr.data
 
     cdef _rebase_time(self, lib.AVRational dst):
 
@@ -75,7 +75,7 @@ cdef class Packet(Buffer):
         if self._time_base.num == dst.num and self._time_base.den == dst.den:
             return
 
-        lib.av_packet_rescale_ts(&self.struct, self._time_base, dst)
+        lib.av_packet_rescale_ts(self.ptr, self._time_base, dst)
 
         self._time_base = dst
 
@@ -101,7 +101,7 @@ cdef class Packet(Buffer):
 
     property stream_index:
         def __get__(self):
-            return self.struct.stream_index
+            return self.ptr.stream_index
 
     property stream:
         """
@@ -112,7 +112,7 @@ cdef class Packet(Buffer):
 
         def __set__(self, Stream stream):
             self._stream = stream
-            self.struct.stream_index = stream._stream.index
+            self.ptr.stream_index = stream._stream.index
 
     property time_base:
         """
@@ -135,14 +135,14 @@ cdef class Packet(Buffer):
         :type: int
         """
         def __get__(self):
-            if self.struct.pts != lib.AV_NOPTS_VALUE:
-                return self.struct.pts
+            if self.ptr.pts != lib.AV_NOPTS_VALUE:
+                return self.ptr.pts
 
         def __set__(self, v):
             if v is None:
-                self.struct.pts = lib.AV_NOPTS_VALUE
+                self.ptr.pts = lib.AV_NOPTS_VALUE
             else:
-                self.struct.pts = v
+                self.ptr.pts = v
 
     property dts:
         """
@@ -151,14 +151,14 @@ cdef class Packet(Buffer):
         :type: int
         """
         def __get__(self):
-            if self.struct.dts != lib.AV_NOPTS_VALUE:
-                return self.struct.dts
+            if self.ptr.dts != lib.AV_NOPTS_VALUE:
+                return self.ptr.dts
 
         def __set__(self, v):
             if v is None:
-                self.struct.dts = lib.AV_NOPTS_VALUE
+                self.ptr.dts = lib.AV_NOPTS_VALUE
             else:
-                self.struct.dts = v
+                self.ptr.dts = v
 
     property pos:
         """
@@ -169,8 +169,8 @@ cdef class Packet(Buffer):
         :type: int
         """
         def __get__(self):
-            if self.struct.pos != -1:
-                return self.struct.pos
+            if self.ptr.pos != -1:
+                return self.ptr.pos
 
     property size:
         """
@@ -179,7 +179,7 @@ cdef class Packet(Buffer):
         :type: int
         """
         def __get__(self):
-            return self.struct.size
+            return self.ptr.size
 
     property duration:
         """
@@ -190,11 +190,11 @@ cdef class Packet(Buffer):
         :type: int
         """
         def __get__(self):
-            if self.struct.duration != lib.AV_NOPTS_VALUE:
-                return self.struct.duration
+            if self.ptr.duration != lib.AV_NOPTS_VALUE:
+                return self.ptr.duration
 
     property is_keyframe:
-        def __get__(self): return bool(self.struct.flags & lib.AV_PKT_FLAG_KEY)
+        def __get__(self): return bool(self.ptr.flags & lib.AV_PKT_FLAG_KEY)
 
     property is_corrupt:
-        def __get__(self): return bool(self.struct.flags & lib.AV_PKT_FLAG_CORRUPT)
+        def __get__(self): return bool(self.ptr.flags & lib.AV_PKT_FLAG_CORRUPT)

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -156,7 +156,7 @@ cdef class Stream(object):
         cdef Packet packet
         for packet in packets:
             packet._stream = self
-            packet.struct.stream_index = self._stream.index
+            packet.ptr.stream_index = self._stream.index
         return packets
 
     def decode(self, packet=None):

--- a/av/subtitles/codeccontext.pyx
+++ b/av/subtitles/codeccontext.pyx
@@ -16,7 +16,7 @@ cdef class SubtitleCodecContext(CodecContext):
             self.ptr,
             &proxy.struct,
             &got_frame,
-            &packet.struct if packet else NULL))
+            packet.ptr if packet else NULL))
         if got_frame:
             return [SubtitleSet(proxy)]
         else:

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -338,8 +338,6 @@ cdef extern from "libavcodec/avcodec.h" nogil:
 
         int64_t pos
 
-        void (*destruct)(AVPacket*)
-
 
     cdef int avcodec_fill_audio_frame(
         AVFrame *frame,
@@ -352,10 +350,10 @@ cdef extern from "libavcodec/avcodec.h" nogil:
 
     cdef void avcodec_free_frame(AVFrame **frame)
 
-    cdef void av_init_packet(AVPacket*)
+    cdef AVPacket* av_packet_alloc()
+    cdef void av_packet_free(AVPacket **)
     cdef int av_new_packet(AVPacket*, int)
     cdef int av_packet_ref(AVPacket *dst, const AVPacket *src)
-    cdef void av_packet_unref(AVPacket *pkt)
     cdef void av_packet_rescale_ts(AVPacket *pkt, AVRational src_tb, AVRational dst_tb)
 
     cdef enum AVSubtitleType:


### PR DESCRIPTION
[`av_init_packet` is deprecated as of FFmpeg 4.4](https://github.com/FFmpeg/FFmpeg/blob/9a194252c78c74c4455f837fd152b61904f5dc85/doc/APIchanges#L224). This PR replaces `av_init_packet` with `av_packet_alloc` and uses `av_packet_free` to both free the `AVPacket` and clear the `AVPacket*` (The replacement functions [have been available since FFmpeg 3.0](https://github.com/FFmpeg/FFmpeg/blob/9a194252c78c74c4455f837fd152b61904f5dc85/doc/APIchanges#L1125)).