### PR TITLE
Fix VideoFrame.to_image with height & width (fixes #878)

### DIFF
--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -233,7 +233,7 @@ cdef class VideoFrame(Frame):
             i_pos += i_stride
             o_pos += o_stride
 
-        return Image.frombytes("RGB", (self.width, self.height), bytes(o_buf), "raw", "RGB", 0, 1)
+        return Image.frombytes("RGB", (plane.width, plane.height), bytes(o_buf), "raw", "RGB", 0, 1)
 
     def to_ndarray(self, **kwargs):
         """Get a numpy array of this frame.

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -149,6 +149,12 @@ class TestVideoFrameImage(TestCase):
             self.assertEqual(img.size, (width, height))
             self.assertEqual(img.tobytes(), expected)
 
+    def test_to_image_with_dimensions(self):
+        frame = VideoFrame(640, 480, format='rgb24')
+
+        img = frame.to_image(width=320, height=240)
+        self.assertEqual(img.size, (320, 240))
+
 
 class TestVideoFrameNdarray(TestCase):
 


### PR DESCRIPTION
If the user passes height / width to VideoFrame.to_image(), the
output of reformat() may have a different size than the original
frame, so we cannot rely on `self.height` or `self.width`.