### PR TITLE
Enable sending EOF to Graphs

### DIFF
--- a/av/filter/context.pyx
+++ b/av/filter/context.pyx
@@ -77,7 +77,10 @@ cdef class FilterContext(object):
 
     def push(self, Frame frame):
 
-        if self.filter.name in ('abuffer', 'buffer'):
+        if frame is None:
+            err_check(lib.av_buffersrc_write_frame(self.ptr, NULL))
+            return
+        elif self.filter.name in ('abuffer', 'buffer'):
             err_check(lib.av_buffersrc_write_frame(self.ptr, frame.ptr))
             return
 

--- a/av/filter/graph.pyx
+++ b/av/filter/graph.pyx
@@ -196,12 +196,14 @@ cdef class Graph(object):
 
     def push(self, frame):
 
-        if isinstance(frame, VideoFrame):
+        if frame is None:
+            contexts = self._context_by_type.get('buffer', []) + self._context_by_type.get('abuffer', [])
+        elif isinstance(frame, VideoFrame):
             contexts = self._context_by_type.get('buffer', [])
         elif isinstance(frame, AudioFrame):
             contexts = self._context_by_type.get('abuffer', [])
         else:
-            raise ValueError('can only push VideoFrame or AudioFrame', type(frame))
+            raise ValueError('can only AudioFrame, VideoFrame or None; got %s' % type(frame))
 
         if len(contexts) != 1:
             raise ValueError('can only auto-push with single buffer; found %s' % len(contexts))


### PR DESCRIPTION
Closes: #886 

This PR adds the ability to send EOF by pushing None on a video `buffer` as proposed in #886 

@jlaine I don't know if you have a preferred code style for the repo, so I didn't apply anything. Let me know if this needs more additions from your side or what is missing to make this complete :)