### PR TITLE
[audio frame] fix ndarray conversion endianness (fixes: #833)

### DIFF
--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -3,6 +3,7 @@ from av.audio.layout cimport get_audio_layout
 from av.audio.plane cimport AudioPlane
 from av.deprecation import renamed_attr
 from av.error cimport err_check
+from av.utils cimport check_ndarray, check_ndarray_shape
 
 
 cdef object _cinit_bypass_sentinel
@@ -116,14 +117,14 @@ cdef class AudioFrame(Frame):
         except KeyError:
             raise ValueError('Conversion from numpy array with format `%s` is not yet supported' % format)
 
+        # check input format
         nb_channels = len(AudioLayout(layout).channels)
-        assert array.dtype == dtype
-        assert array.ndim == 2
+        check_ndarray(array, dtype, 2)
         if AudioFormat(format).is_planar:
-            assert array.shape[0] == nb_channels
+            check_ndarray_shape(array, array.shape[0] == nb_channels)
             samples = array.shape[1]
         else:
-            assert array.shape[0] == 1
+            check_ndarray_shape(array, array.shape[0] == 1)
             samples = array.shape[1] // nb_channels
 
         frame = AudioFrame(format=format, layout=layout, samples=samples)

--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -9,14 +9,14 @@ cdef object _cinit_bypass_sentinel
 
 
 format_dtypes = {
-    'dbl': '<f8',
-    'dblp': '<f8',
-    'flt': '<f4',
-    'fltp': '<f4',
-    's16': '<i2',
-    's16p': '<i2',
-    's32': '<i4',
-    's32p': '<i4',
+    'dbl': 'f8',
+    'dblp': 'f8',
+    'flt': 'f4',
+    'fltp': 'f4',
+    's16': 'i2',
+    's16p': 'i2',
+    's32': 'i4',
+    's32p': 'i4',
     'u8': 'u1',
     'u8p': 'u1',
 }

--- a/av/utils.pxd
+++ b/av/utils.pxd
@@ -10,4 +10,6 @@ cdef object avrational_to_fraction(const lib.AVRational *input)
 cdef object to_avrational(object value, lib.AVRational *input)
 
 
+cdef check_ndarray(object array, object dtype, int ndim)
+cdef check_ndarray_shape(object array, bint ok)
 cdef flag_in_bitfield(uint64_t bitfield, uint64_t flag)

--- a/av/utils.pyx
+++ b/av/utils.pyx
@@ -61,6 +61,25 @@ cdef object to_avrational(object value, lib.AVRational *input):
 # === OTHER ===
 # =============
 
+
+cdef check_ndarray(object array, object dtype, int ndim):
+    """
+    Check a numpy array has the expected data type and number of dimensions.
+    """
+    if array.dtype != dtype:
+        raise ValueError(f"Expected numpy array with dtype `{dtype}` but got `{array.dtype}`")
+    if array.ndim != ndim:
+        raise ValueError(f"Expected numpy array with ndim `{ndim}` but got `{array.ndim}`")
+
+
+cdef check_ndarray_shape(object array, bint ok):
+    """
+    Check a numpy array has the expected shape.
+    """
+    if not ok:
+        raise ValueError(f"Unexpected numpy array shape `{array.shape}`")
+
+
 cdef flag_in_bitfield(uint64_t bitfield, uint64_t flag):
     # Not every flag exists in every version of FFMpeg, so we define them to 0.
     if not flag:

--- a/tests/test_audioframe.py
+++ b/tests/test_audioframe.py
@@ -114,6 +114,25 @@ class TestAudioFrameConveniences(TestCase):
             self.assertEqual(frame.samples, 160)
             self.assertTrue((frame.to_ndarray() == array).all())
 
+    def test_from_ndarray_value_error(self):
+        # incorrect dtype
+        array = numpy.ndarray(shape=(1, 160), dtype="f2")
+        with self.assertRaises(ValueError) as cm:
+            AudioFrame.from_ndarray(array, format="flt", layout="mono")
+        self.assertEqual(str(cm.exception), "Expected numpy array with dtype `float32` but got `float16`")
+
+        # incorrect number of dimensions
+        array = numpy.ndarray(shape=(1, 160, 2), dtype="f4")
+        with self.assertRaises(ValueError) as cm:
+            AudioFrame.from_ndarray(array, format="flt", layout="mono")
+        self.assertEqual(str(cm.exception), "Expected numpy array with ndim `2` but got `3`")
+
+        # incorrect shape
+        array = numpy.ndarray(shape=(2, 160), dtype="f4")
+        with self.assertRaises(ValueError) as cm:
+            AudioFrame.from_ndarray(array, format="flt", layout="mono")
+        self.assertEqual(str(cm.exception), "Unexpected numpy array shape `(2, 160)`")
+
     def test_ndarray_flt(self):
         layouts = [
             ('flt', 'mono', 'f4', (1, 160)),

--- a/tests/test_audioframe.py
+++ b/tests/test_audioframe.py
@@ -81,7 +81,7 @@ class TestAudioFrameConveniences(TestCase):
     def test_basic_to_ndarray(self):
         frame = AudioFrame(format='s16p', layout='stereo', samples=160)
         array = frame.to_ndarray()
-        self.assertEqual(array.dtype, '<i2')
+        self.assertEqual(array.dtype, 'i2')
         self.assertEqual(array.shape, (2, 160))
 
     def test_basic_to_nd_array(self):
@@ -99,10 +99,10 @@ class TestAudioFrameConveniences(TestCase):
 
     def test_ndarray_dbl(self):
         layouts = [
-            ('dbl', 'mono', '<f8', (1, 160)),
-            ('dbl', 'stereo', '<f8', (1, 320)),
-            ('dblp', 'mono', '<f8', (1, 160)),
-            ('dblp', 'stereo', '<f8', (2, 160)),
+            ('dbl', 'mono', 'f8', (1, 160)),
+            ('dbl', 'stereo', 'f8', (1, 320)),
+            ('dblp', 'mono', 'f8', (1, 160)),
+            ('dblp', 'stereo', 'f8', (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.ndarray(shape=size, dtype=dtype)
@@ -116,10 +116,10 @@ class TestAudioFrameConveniences(TestCase):
 
     def test_ndarray_flt(self):
         layouts = [
-            ('flt', 'mono', '<f4', (1, 160)),
-            ('flt', 'stereo', '<f4', (1, 320)),
-            ('fltp', 'mono', '<f4', (1, 160)),
-            ('fltp', 'stereo', '<f4', (2, 160)),
+            ('flt', 'mono', 'f4', (1, 160)),
+            ('flt', 'stereo', 'f4', (1, 320)),
+            ('fltp', 'mono', 'f4', (1, 160)),
+            ('fltp', 'stereo', 'f4', (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.ndarray(shape=size, dtype=dtype)
@@ -133,10 +133,10 @@ class TestAudioFrameConveniences(TestCase):
 
     def test_ndarray_s16(self):
         layouts = [
-            ('s16', 'mono', '<i2', (1, 160)),
-            ('s16', 'stereo', '<i2', (1, 320)),
-            ('s16p', 'mono', '<i2', (1, 160)),
-            ('s16p', 'stereo', '<i2', (2, 160)),
+            ('s16', 'mono', 'i2', (1, 160)),
+            ('s16', 'stereo', 'i2', (1, 320)),
+            ('s16p', 'mono', 'i2', (1, 160)),
+            ('s16p', 'stereo', 'i2', (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.random.randint(0, 256, size=size, dtype=dtype)
@@ -149,15 +149,15 @@ class TestAudioFrameConveniences(TestCase):
     def test_ndarray_s16p_align_8(self):
         frame = AudioFrame(format='s16p', layout='stereo', samples=159, align=8)
         array = frame.to_ndarray()
-        self.assertEqual(array.dtype, '<i2')
+        self.assertEqual(array.dtype, 'i2')
         self.assertEqual(array.shape, (2, 159))
 
     def test_ndarray_s32(self):
         layouts = [
-            ('s32', 'mono', '<i4', (1, 160)),
-            ('s32', 'stereo', '<i4', (1, 320)),
-            ('s32p', 'mono', '<i4', (1, 160)),
-            ('s32p', 'stereo', '<i4', (2, 160)),
+            ('s32', 'mono', 'i4', (1, 160)),
+            ('s32', 'stereo', 'i4', (1, 320)),
+            ('s32p', 'mono', 'i4', (1, 160)),
+            ('s32p', 'stereo', 'i4', (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.random.randint(0, 256, size=size, dtype=dtype)


### PR DESCRIPTION
We assumed that sample data is always stored in little-endian order, but
that is not the case according to the FFmpeg documentation:

    The data described by the sample format is always in native-endian order.