### PR TITLE
[audio] make resampler consistently flush buffer

### DIFF
--- a/av/audio/codeccontext.pxd
+++ b/av/audio/codeccontext.pxd
@@ -1,5 +1,4 @@
 
-from av.audio.fifo cimport AudioFifo
 from av.audio.frame cimport AudioFrame
 from av.audio.resampler cimport AudioResampler
 from av.codec.context cimport CodecContext
@@ -12,4 +11,3 @@ cdef class AudioCodecContext(CodecContext):
 
     # For encoding.
     cdef AudioResampler resampler
-    cdef AudioFifo fifo

--- a/av/audio/codeccontext.pyx
+++ b/av/audio/codeccontext.pyx
@@ -39,13 +39,7 @@ cdef class AudioCodecContext(CodecContext):
                 rate=self.ptr.sample_rate,
                 frame_size=None if allow_var_frame_size else self.ptr.frame_size
             )
-        frames = self.resampler.resample(frame)
-
-        # flush if input frame is None
-        if input_frame is None:
-            frames.append(None)
-
-        return frames
+        return self.resampler.resample(frame)
 
     cdef Frame _alloc_next_frame(self):
         return alloc_audio_frame()

--- a/av/audio/resampler.pxd
+++ b/av/audio/resampler.pxd
@@ -1,6 +1,3 @@
-from libc.stdint cimport uint64_t
-cimport libav as lib
-
 from av.audio.format cimport AudioFormat
 from av.audio.frame cimport AudioFrame
 from av.audio.layout cimport AudioLayout
@@ -10,8 +7,6 @@ from av.filter.graph cimport Graph
 cdef class AudioResampler(object):
 
     cdef readonly bint is_passthrough
-
-    cdef lib.SwrContext *ptr
 
     cdef AudioFrame template
 

--- a/av/audio/resampler.pyx
+++ b/av/audio/resampler.pyx
@@ -1,11 +1,9 @@
-from libc.stdint cimport int64_t, uint8_t
 cimport libav as lib
 
 from av.filter.context cimport FilterContext
 
 import errno
 
-from av.error import FFmpegError
 import av.filter
 
 

--- a/tests/test_audioresampler.py
+++ b/tests/test_audioresampler.py
@@ -6,76 +6,194 @@ from .common import TestCase
 
 
 class TestAudioResampler(TestCase):
-    def test_identity_passthrough(self):
-
-        # If we don't ask it to do anything, it won't.
+    def test_flush_immediately(self):
+        """
+        If we flush the resampler before passing any input, it returns
+        a `None` frame without setting up the graph.
+        """
 
         resampler = AudioResampler()
 
-        iframe = AudioFrame("s16", "stereo", 1024)
-        oframe = resampler.resample(iframe)[0]
+        # flush
+        oframes = resampler.resample(None)
+        self.assertEqual(len(oframes), 1)
+        self.assertIsNone(oframes[0])
 
-        self.assertIs(iframe, oframe)
+    def test_identity_passthrough(self):
+        """
+        If we don't ask it to do anything, it won't.
+        """
+
+        resampler = AudioResampler()
+
+        # resample one frame
+        iframe = AudioFrame("s16", "stereo", 1024)
+
+        oframes = resampler.resample(iframe)
+        self.assertEqual(len(oframes), 1)
+        self.assertIs(iframe, oframes[0])
+
+        # resample another frame
+        iframe.pts = 1024
+
+        oframes = resampler.resample(iframe)
+        self.assertEqual(len(oframes), 1)
+        self.assertIs(iframe, oframes[0])
+
+        # flush
+        oframes = resampler.resample(None)
+        self.assertEqual(len(oframes), 1)
+        self.assertIsNone(oframes[0])
 
     def test_matching_passthrough(self):
-
-        # If the frames match, it won't do anything.
+        """
+        If the frames match, it won't do anything.
+        """
 
         resampler = AudioResampler("s16", "stereo")
 
+        # resample one frame
         iframe = AudioFrame("s16", "stereo", 1024)
-        oframe = resampler.resample(iframe)[0]
 
-        self.assertIs(iframe, oframe)
+        oframes = resampler.resample(iframe)
+        self.assertEqual(len(oframes), 1)
+        self.assertIs(iframe, oframes[0])
+
+        # resample another frame
+        iframe.pts = 1024
+
+        oframes = resampler.resample(iframe)
+        self.assertEqual(len(oframes), 1)
+        self.assertIs(iframe, oframes[0])
+
+        # flush
+        oframes = resampler.resample(None)
+        self.assertEqual(len(oframes), 1)
+        self.assertIsNone(oframes[0])
 
     def test_pts_assertion_same_rate(self):
 
         resampler = AudioResampler("s16", "mono")
 
+        # resample one frame
         iframe = AudioFrame("s16", "stereo", 1024)
         iframe.sample_rate = 48000
         iframe.time_base = "1/48000"
         iframe.pts = 0
 
-        oframe = resampler.resample(iframe)[0]
+        oframes = resampler.resample(iframe)
+        self.assertEqual(len(oframes), 1)
 
+        oframe = oframes[0]
         self.assertEqual(oframe.pts, 0)
         self.assertEqual(oframe.time_base, iframe.time_base)
         self.assertEqual(oframe.sample_rate, iframe.sample_rate)
+        self.assertEqual(oframe.samples, iframe.samples)
 
+        # resample another frame
         iframe.pts = 1024
-        oframe = resampler.resample(iframe)[0]
 
+        oframes = resampler.resample(iframe)
+        self.assertEqual(len(oframes), 1)
+
+        oframe = oframes[0]
         self.assertEqual(oframe.pts, 1024)
         self.assertEqual(oframe.time_base, iframe.time_base)
         self.assertEqual(oframe.sample_rate, iframe.sample_rate)
+        self.assertEqual(oframe.samples, iframe.samples)
 
+        # resample another frame with a pts gap, do not raise exception
         iframe.pts = 9999
-        resampler.resample(iframe)  # resampler should handle this without an exception
+        oframes = resampler.resample(iframe)
+        self.assertEqual(len(oframes), 1)
+
+        oframe = oframes[0]
+        self.assertEqual(oframe.pts, 9999)
+        self.assertEqual(oframe.time_base, iframe.time_base)
+        self.assertEqual(oframe.sample_rate, iframe.sample_rate)
+        self.assertEqual(oframe.samples, iframe.samples)
+
+        # flush
+        oframes = resampler.resample(None)
+        self.assertEqual(len(oframes), 1)
+        self.assertIsNone(oframes[0])
 
     def test_pts_assertion_new_rate(self):
 
         resampler = AudioResampler("s16", "mono", 44100)
 
+        # resample one frame
         iframe = AudioFrame("s16", "stereo", 1024)
         iframe.sample_rate = 48000
         iframe.time_base = "1/48000"
         iframe.pts = 0
 
-        oframe = resampler.resample(iframe)[0]
+        oframes = resampler.resample(iframe)
+        self.assertEqual(len(oframes), 1)
+
+        oframe = oframes[0]
         self.assertEqual(oframe.pts, 0)
-        self.assertEqual(str(oframe.time_base), "1/44100")
+        self.assertEqual(oframe.time_base, Fraction(1, 44100))
         self.assertEqual(oframe.sample_rate, 44100)
+        self.assertEqual(oframe.samples, 925)
+
+        # flush
+        oframes = resampler.resample(None)
+        self.assertEqual(len(oframes), 2)
+
+        oframe = oframes[0]
+        self.assertEqual(oframe.pts, 925)
+        self.assertEqual(oframe.time_base, Fraction(1, 44100))
+        self.assertEqual(oframe.sample_rate, 44100)
+        self.assertEqual(oframe.samples, 16)
+
+        self.assertIsNone(oframes[1])
 
     def test_pts_missing_time_base(self):
 
         resampler = AudioResampler("s16", "mono", 44100)
 
+        # resample one frame
         iframe = AudioFrame("s16", "stereo", 1024)
         iframe.sample_rate = 48000
         iframe.pts = 0
 
-        oframe = resampler.resample(iframe)[0]
+        oframes = resampler.resample(iframe)
+        self.assertEqual(len(oframes), 1)
+
+        oframe = oframes[0]
         self.assertEqual(oframe.pts, 0)
         self.assertEqual(oframe.time_base, Fraction(1, 44100))
         self.assertEqual(oframe.sample_rate, 44100)
+
+        # flush
+        oframes = resampler.resample(None)
+        self.assertEqual(len(oframes), 2)
+
+        oframe = oframes[0]
+        self.assertEqual(oframe.pts, 925)
+        self.assertEqual(oframe.time_base, Fraction(1, 44100))
+        self.assertEqual(oframe.sample_rate, 44100)
+        self.assertEqual(oframe.samples, 16)
+
+        self.assertIsNone(oframes[1])
+
+    def test_mismatched_input(self):
+        """
+        Consecutive frames must have the same layout, sample format and sample rate.
+        """
+        resampler = AudioResampler("s16", "mono", 44100)
+
+        # resample one frame
+        iframe = AudioFrame("s16", "stereo", 1024)
+        iframe.sample_rate = 48000
+        resampler.resample(iframe)
+
+        # resample another frame with a sample format
+        iframe = AudioFrame("s16", "mono", 1024)
+        iframe.sample_rate = 48000
+        with self.assertRaises(ValueError) as cm:
+            resampler.resample(iframe)
+        self.assertEqual(
+            str(cm.exception), "Frame does not match AudioResampler setup."
+        )


### PR DESCRIPTION
In the previous behaviour it was only possible to perform flushing for a
"passthrough" resampler, dropping the final frames if actual resampling
was required.