### PR TITLE
Remove deprecated methods

### DIFF
--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -1,7 +1,6 @@
 from av.audio.format cimport get_audio_format
 from av.audio.layout cimport get_audio_layout
 from av.audio.plane cimport AudioPlane
-from av.deprecation import renamed_attr
 from av.error cimport err_check
 from av.utils cimport check_ndarray, check_ndarray_shape
 
@@ -195,5 +194,3 @@ cdef class AudioFrame(Frame):
 
         # convert and return data
         return np.vstack([np.frombuffer(x, dtype=dtype, count=count) for x in self.planes])
-
-    to_nd_array = renamed_attr('to_ndarray')

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -13,8 +13,6 @@ from av.utils cimport (
     to_avrational
 )
 
-from av import deprecation
-
 
 cdef object _cinit_bypass_sentinel = object()
 
@@ -174,19 +172,6 @@ cdef class Stream(object):
         .. seealso:: This is mostly a passthrough to :meth:`.CodecContext.decode`.
         """
         return self.codec_context.decode(packet)
-
-    @deprecation.method
-    def seek(self, offset, **kwargs):
-        """
-        .. seealso:: :meth:`.InputContainer.seek` for documentation on parameters.
-            The only difference is that ``offset`` will be interpreted in
-            :attr:`.Stream.time_base` when ``whence == 'time'``.
-
-        .. deprecated:: 6.1.0
-            Use :meth:`.InputContainer.seek` with ``stream`` argument instead.
-
-        """
-        self.container.seek(offset, stream=self, **kwargs)
 
     property id:
         """

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -6,8 +6,6 @@ from av.utils cimport check_ndarray, check_ndarray_shape
 from av.video.format cimport VideoFormat, get_pix_fmt, get_video_format
 from av.video.plane cimport VideoPlane
 
-from av.deprecation import renamed_attr
-
 
 cdef object _cinit_bypass_sentinel
 
@@ -275,8 +273,6 @@ cdef class VideoFrame(Frame):
             return image, palette
         else:
             raise ValueError('Conversion to numpy array with format `%s` is not yet supported' % frame.format.name)
-
-    to_nd_array = renamed_attr('to_ndarray')
 
     @staticmethod
     def from_image(img):

--- a/tests/test_audioframe.py
+++ b/tests/test_audioframe.py
@@ -1,9 +1,6 @@
-import warnings
-
 import numpy
 
 from av import AudioFrame
-from av.deprecation import AttributeRenamedWarning
 
 from .common import TestCase
 
@@ -81,20 +78,6 @@ class TestAudioFrameConveniences(TestCase):
         array = frame.to_ndarray()
         self.assertEqual(array.dtype, "i2")
         self.assertEqual(array.shape, (2, 160))
-
-    def test_basic_to_nd_array(self):
-        frame = AudioFrame(format="s16p", layout="stereo", samples=160)
-        with warnings.catch_warnings(record=True) as recorded:
-            array = frame.to_nd_array()
-        self.assertEqual(array.shape, (2, 160))
-
-        # check deprecation warning
-        self.assertEqual(len(recorded), 1)
-        self.assertEqual(recorded[0].category, AttributeRenamedWarning)
-        self.assertEqual(
-            str(recorded[0].message),
-            "AudioFrame.to_nd_array is deprecated; please use AudioFrame.to_ndarray.",
-        )
 
     def test_ndarray_dbl(self):
         layouts = [

--- a/tests/test_seek.py
+++ b/tests/test_seek.py
@@ -1,7 +1,6 @@
 from __future__ import division
 
 import unittest
-import warnings
 
 import av
 
@@ -27,7 +26,6 @@ class TestSeek(TestCase):
     def test_seek_float(self):
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
         self.assertRaises(TypeError, container.seek, 1.0)
-        self.assertRaises(TypeError, container.streams.video[0].seek, 1.0)
 
     def test_seek_int64(self):
         # Assert that it accepts large values.
@@ -128,7 +126,7 @@ class TestSeek(TestCase):
 
         self.assertEqual(frame_count, total_frame_count - target_frame)
 
-    def test_stream_seek(self, use_deprecated_api=False):
+    def test_stream_seek(self):
 
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
 
@@ -147,14 +145,7 @@ class TestSeek(TestCase):
         target_sec = target_frame * 1 / rate
 
         target_timestamp = int(target_sec / time_base) + video_stream.start_time
-
-        if use_deprecated_api:
-            with warnings.catch_warnings(record=True) as captured:
-                video_stream.seek(target_timestamp)
-            self.assertEqual(len(captured), 1)
-            self.assertIn("Stream.seek is deprecated.", captured[0].message.args[0])
-        else:
-            container.seek(target_timestamp, stream=video_stream)
+        container.seek(target_timestamp, stream=video_stream)
 
         current_frame = None
         frame_count = 0
@@ -172,9 +163,6 @@ class TestSeek(TestCase):
                     frame_count += 1
 
         self.assertEqual(frame_count, total_frame_count - target_frame)
-
-    def test_deprecated_stream_seek(self):
-        self.test_stream_seek(use_deprecated_api=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -1,10 +1,8 @@
 from unittest import SkipTest
-import warnings
 
 import numpy
 
 from av import VideoFrame
-from av.deprecation import AttributeRenamedWarning
 
 from .common import Image, TestCase, fate_png
 
@@ -158,20 +156,6 @@ class TestVideoFrameNdarray(TestCase):
         frame = VideoFrame(640, 480, "rgb24")
         array = frame.to_ndarray()
         self.assertEqual(array.shape, (480, 640, 3))
-
-    def test_basic_to_nd_array(self):
-        frame = VideoFrame(640, 480, "rgb24")
-        with warnings.catch_warnings(record=True) as recorded:
-            array = frame.to_nd_array()
-        self.assertEqual(array.shape, (480, 640, 3))
-
-        # check deprecation warning
-        self.assertEqual(len(recorded), 1)
-        self.assertEqual(recorded[0].category, AttributeRenamedWarning)
-        self.assertEqual(
-            str(recorded[0].message),
-            "VideoFrame.to_nd_array is deprecated; please use VideoFrame.to_ndarray.",
-        )
 
     def test_ndarray_gray(self):
         array = numpy.random.randint(0, 256, size=(480, 640), dtype=numpy.uint8)


### PR DESCRIPTION
The following deprecated methods are removed:

- AudioFrame.to_nd_array
- VideoFrame.to_nd_array
- Stream.seek