### PR TITLE
[streams] prune some dead code

### DIFF
--- a/av/audio/stream.pyx
+++ b/av/audio/stream.pyx
@@ -1,4 +1,3 @@
-
 cdef class AudioStream(Stream):
 
     def __repr__(self):

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -260,7 +260,7 @@ cdef class Stream(object):
         """The guessed frame rate of this stream.
 
         This is a wrapper around :ffmpeg:`av_guess_frame_rate`, and uses multiple
-        huristics to decide what is "the" frame rate.
+        heuristics to decide what is "the" frame rate.
 
         :type: :class:`~fractions.Fraction` or ``None``
 

--- a/av/video/stream.pxd
+++ b/av/video/stream.pxd
@@ -1,4 +1,3 @@
-
 from av.stream cimport Stream
 
 

--- a/av/video/stream.pyx
+++ b/av/video/stream.pyx
@@ -1,10 +1,3 @@
-from libc.stdint cimport int64_t
-cimport libav as lib
-
-from av.container.core cimport Container
-from av.utils cimport avrational_to_fraction
-
-
 cdef class VideoStream(Stream):
 
     def __repr__(self):
@@ -17,7 +10,3 @@ cdef class VideoStream(Stream):
             self._codec_context.height,
             id(self),
         )
-
-    property average_rate:
-        def __get__(self):
-            return avrational_to_fraction(&self._stream.avg_frame_rate)


### PR DESCRIPTION
- the `average_rate` is already defined on the base Stream class, we do
  not need to redefine it in VideoStream
- prune unused imports from AudioStream and VideoStream
- fix a typo in the `guessed_rate` docstring