### PR TITLE
[buffer] deprecate Buffer.to_bytes()

### DIFF
--- a/av/buffer.pyx
+++ b/av/buffer.pyx
@@ -1,6 +1,7 @@
 from cpython cimport PyBUF_WRITABLE, PyBuffer_FillInfo
 from libc.string cimport memcpy
 
+from av import deprecation
 from av.bytesource cimport ByteSource, bytesource
 
 
@@ -35,6 +36,7 @@ cdef class Buffer(object):
         """The memory address of the buffer."""
         return <size_t>self._buffer_ptr()
 
+    @deprecation.method
     def to_bytes(self):
         """Return the contents of this buffer as ``bytes``.
 

--- a/scratchpad/audio.py
+++ b/scratchpad/audio.py
@@ -10,7 +10,7 @@ import av
 
 def print_data(frame):
     for i, plane in enumerate(frame.planes or ()):
-        data = plane.to_bytes()
+        data = bytes(plane)
         print('\tPLANE %d, %d bytes' % (i, len(data)))
         data = data.encode('hex')
         for i in xrange(0, len(data), 128):
@@ -91,7 +91,7 @@ for i, packet in enumerate(container.demux(stream)):
                 ffplay = subprocess.Popen(cmd, stdin=subprocess.PIPE)
             try:
                 for frame in frames:
-                    ffplay.stdin.write(frame.planes[0].to_bytes())
+                    ffplay.stdin.write(bytes(frame.planes[0]))
             except IOError as e:
                 print(e)
                 exit()

--- a/scratchpad/audio_player.py
+++ b/scratchpad/audio_player.py
@@ -60,7 +60,7 @@ for pi, fi, frame in decode_iter():
     print('pts: %.3f, played: %.3f, buffered: %.3f' % (frame.time or 0, us_processed / 1000000.0, us_buffered / 1000000.0))
 
 
-    data = frame.planes[0].to_bytes()
+    data = bytes(frame.planes[0])
     while data:
         written = device.write(data)
         if written:

--- a/scratchpad/decode.py
+++ b/scratchpad/decode.py
@@ -144,7 +144,7 @@ for i, packet in enumerate(container.demux(streams)):
                 ]
                 proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
             try:
-                proc.stdin.write(frame.planes[0].to_bytes())
+                proc.stdin.write(bytes(frame.planes[0]))
             except IOError as e:
                 print(e)
                 exit()
@@ -152,7 +152,7 @@ for i, packet in enumerate(container.demux(streams)):
         if args.dump_planes:
             print('\t\tplanes')
             for i, plane in enumerate(frame.planes or ()):
-                data = plane.to_bytes()
+                data = bytes(plane)
                 print('\t\t\tPLANE %d, %d bytes' % (i, len(data)))
                 data = data.encode('hex')
                 for i in xrange(0, len(data), 128):

--- a/tests/test_audiofifo.py
+++ b/tests/test_audiofifo.py
@@ -16,10 +16,10 @@ class TestAudioFifo(TestCase):
 
         for i, packet in enumerate(container.demux(stream)):
             for frame in packet.decode():
-                input_.append(frame.planes[0].to_bytes())
+                input_.append(bytes(frame.planes[0]))
                 fifo.write(frame)
                 for frame in fifo.read_many(512, partial=i == 10):
-                    output.append(frame.planes[0].to_bytes())
+                    output.append(bytes(frame.planes[0]))
             if i == 10:
                 break
 

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -116,7 +116,7 @@ class TestCodecContext(TestCase):
         for packet in fh.demux(video=0):
             packets.append(packet)
 
-        full_source = b"".join(p.to_bytes() for p in packets)
+        full_source = b"".join(bytes(p) for p in packets)
 
         for size in 1024, 8192, 65535:
 
@@ -128,7 +128,7 @@ class TestCodecContext(TestCase):
                 packets.extend(ctx.parse(block))
             packets.extend(ctx.parse())
 
-            parsed_source = b"".join(p.to_bytes() for p in packets)
+            parsed_source = b"".join(bytes(p) for p in packets)
             self.assertEqual(len(parsed_source), len(full_source))
             self.assertEqual(full_source, parsed_source)
 


### PR DESCRIPTION
This method is no longer needed since with Python 3 we can simply use
bytes(buf).