### PR TITLE
Support AV_FRAME_DATA_SEI_UNREGISTERED (fixes: #723)

### DIFF
--- a/av/enum.pyx
+++ b/av/enum.pyx
@@ -384,6 +384,7 @@ cpdef define_enum(name, module, items, bint is_flags=False):
     else:
         base_cls = EnumItem
 
-    cls = EnumType(name, (base_cls, ), {'__module__': module}, items)
+    # Some items may be None if they correspond to an unsupported FFmpeg feature
+    cls = EnumType(name, (base_cls, ), {'__module__': module}, [i for i in items if i is not None])
 
     return cls

--- a/av/sidedata/sidedata.pyx
+++ b/av/sidedata/sidedata.pyx
@@ -25,6 +25,8 @@ Type = define_enum('Type', __name__, (
     ('SPHERICAL', lib.AV_FRAME_DATA_SPHERICAL),
     ('CONTENT_LIGHT_LEVEL', lib.AV_FRAME_DATA_CONTENT_LIGHT_LEVEL),
     ('ICC_PROFILE', lib.AV_FRAME_DATA_ICC_PROFILE),
+    # SEI_UNREGISTERED available since version 56.54.100 of libavutil (FFmpeg >= 4.4)
+    ('SEI_UNREGISTERED', lib.AV_FRAME_DATA_SEI_UNREGISTERED) if lib.AV_FRAME_DATA_SEI_UNREGISTERED != -1 else None,
 
     # These are deprecated. See https://github.com/PyAV-Org/PyAV/issues/607
     # ('QP_TABLE_PROPERTIES', lib.AV_FRAME_DATA_QP_TABLE_PROPERTIES),

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -7,6 +7,14 @@ from libc.stdint cimport (
 
 
 cdef extern from "libavcodec/avcodec.h" nogil:
+    """
+    // AV_FRAME_DATA_SEI_UNREGISTERED available since version 56.54.100 of libavutil (FFmpeg >= 4.4)
+    #define HAS_AV_FRAME_DATA_SEI_UNREGISTERED  (LIBAVUTIL_VERSION_INT >= 3683940)
+
+    #if !HAS_AV_FRAME_DATA_SEI_UNREGISTERED
+        #define AV_FRAME_DATA_SEI_UNREGISTERED -1
+    #endif
+    """
 
     # custom
     cdef set pyav_get_available_codecs()
@@ -280,6 +288,7 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         AV_FRAME_DATA_ICC_PROFILE
         AV_FRAME_DATA_QP_TABLE_PROPERTIES
         AV_FRAME_DATA_QP_TABLE_DATA
+        AV_FRAME_DATA_SEI_UNREGISTERED
 
     cdef struct AVFrameSideData:
         AVFrameSideDataType type


### PR DESCRIPTION
Hi,

I'm interested in solving #723, but since it relies on a FFmpeg >= 4.4 feature, I am not sure how to proceed to avoid breaking builds relying on older versions.

Still, with a FFmpeg 4.4 build from source + this patch, I was able to retrieve the SEI side data.