### PR TITLE
Ensure probing a corrupt file does not crash (fixes: #590)

### DIFF
--- a/av/audio/format.pyx
+++ b/av/audio/format.pyx
@@ -8,6 +8,10 @@ cdef object _cinit_bypass_sentinel
 
 cdef AudioFormat get_audio_format(lib.AVSampleFormat c_format):
     """Get an AudioFormat without going through a string."""
+
+    if c_format < 0:
+        return None
+
     cdef AudioFormat format = AudioFormat.__new__(AudioFormat, _cinit_bypass_sentinel)
     format._init(c_format)
     return format

--- a/av/audio/stream.pyx
+++ b/av/audio/stream.pyx
@@ -7,6 +7,6 @@ cdef class AudioStream(Stream):
             self.name,
             self.rate,
             self.layout.name,
-            self.format.name,
+            self.format.name if self.format else None,
             id(self),
         )

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -73,10 +73,14 @@ cdef class InputContainer(Container):
         close_input(self)
 
     property start_time:
-        def __get__(self): return self.ptr.start_time
+        def __get__(self):
+            if self.ptr.start_time != lib.AV_NOPTS_VALUE:
+                return self.ptr.start_time
 
     property duration:
-        def __get__(self): return self.ptr.duration
+        def __get__(self):
+            if self.ptr.duration != lib.AV_NOPTS_VALUE:
+                return self.ptr.duration
 
     property bit_rate:
         def __get__(self): return self.ptr.bit_rate

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -19,6 +19,24 @@ class TestDecode(TestCase):
 
         self.assertEqual(frame_count, video_stream.frames)
 
+    def test_decode_audio_corrupt(self):
+        # write an empty file
+        path = self.sandboxed("empty.flac")
+        with open(path, "wb"):
+            pass
+
+        packet_count = 0
+        frame_count = 0
+
+        with av.open(path) as container:
+            for packet in container.demux(audio=0):
+                for frame in packet.decode():
+                    frame_count += 1
+                packet_count += 1
+
+        self.assertEqual(packet_count, 1)
+        self.assertEqual(frame_count, 0)
+
     def test_decode_audio_sample_count(self):
 
         container = av.open(fate_suite("audio-reference/chorusnoise_2ch_44kHz_s16.wav"))
@@ -79,3 +97,21 @@ class TestDecode(TestCase):
                 if not frame.key_frame:
                     assert vectors is None
                     return
+
+    def test_decode_video_corrupt(self):
+        # write an empty file
+        path = self.sandboxed("empty.h264")
+        with open(path, "wb"):
+            pass
+
+        packet_count = 0
+        frame_count = 0
+
+        with av.open(path) as container:
+            for packet in container.demux(video=0):
+                for frame in packet.decode():
+                    frame_count += 1
+                packet_count += 1
+
+        self.assertEqual(packet_count, 1)
+        self.assertEqual(frame_count, 0)


### PR DESCRIPTION
- make get_audio_format() return None for invalid formats
- fix AudioStream.__repr__ to deal with this situation