### PR TITLE
Add CIBW_REPAIR_WHEEL_COMMAND_MACOS to workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,6 +242,9 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: pip install cython && python scripts\fetch-vendor.py C:\cibw\vendor
           CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH=/tmp/vendor/lib:$LD_LIBRARY_PATH PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig
           CIBW_ENVIRONMENT_MACOS: PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig LDFLAGS=-headerpad_max_install_names
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+              DYLD_LIBRARY_PATH=/tmp/vendor/lib delocate-listdeps {wheel} &&
+              DYLD_LIBRARY_PATH=/tmp/vendor/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
           CIBW_ENVIRONMENT_WINDOWS: INCLUDE=C:\\cibw\\vendor\\include LIB=C:\\cibw\\vendor\\lib PYAV_SKIP_TESTS=unicode_filename
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python scripts/inject-dll {wheel} {dest_dir} C:\cibw\vendor\bin
           CIBW_SKIP: cp36-* pp36-* pp38-win* *-musllinux*


### PR DESCRIPTION
Add CIBW_REPAIR_WHEEL_COMMAND_MACOS to fix wheel building issues when compiling with libvpx support.
See https://github.com/PyAV-Org/pyav-ffmpeg/pull/51 for context.