### PR TITLE
Ensure `close` is called when Container is deleted

### DIFF
--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -244,6 +244,9 @@ cdef class Container(object):
             # Finish releasing the whole structure.
             lib.avformat_free_context(self.ptr)
 
+    def __del__(self):
+        self.close()
+        
     def __enter__(self):
         return self
 


### PR DESCRIPTION
Currently, close() is only called when using a context manager. This can demonstrably lead to hangs when using AUTO threading mode as shown in the cookbook example.

As @jlaine discovered in #909, calling `close()` on the Container seems to resolve the issue, likely by making sure the threads have been joined by the time __dealloc__ runs.