### PR TITLE
[package] update FFmpeg binaries

### DIFF
--- a/scripts/fetch-vendor.json
+++ b/scripts/fetch-vendor.json
@@ -1,3 +1,3 @@
 {
-    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/4.4.1-5/ffmpeg-{platform}.tar.gz"]
+    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/4.4.1-6/ffmpeg-{platform}.tar.gz"]
 }


### PR DESCRIPTION
- VPX is enabled on all platforms
- the Windows build disable mediafoundation support as it drags in a
  dependency on MFPlat.DLL