### PR TITLE
Free packet used for muxing in OutputContainer

### DIFF
--- a/av/container/output.pxd
+++ b/av/container/output.pxd
@@ -8,5 +8,6 @@ cdef class OutputContainer(Container):
 
     cdef bint _started
     cdef bint _done
+    cdef lib.AVPacket *packet_ptr
 
     cpdef start_encoding(self)


### PR DESCRIPTION
https://github.com/PyAV-Org/PyAV/pull/872 seems to have introduced a memory leak as the packet that is allocated in `mux_one` is not freed. This PR adds a packet_ptr to the OutputContainer which follows the OutputContainer's lifecycle and is freed in its `__dealloc__`.
