### PR TITLE
[codec context] deprecate CodecContext.time_base for decoders

### DIFF
--- a/docs/api/time.rst
+++ b/docs/api/time.rst
@@ -29,9 +29,6 @@ Time is expressed as integer multiples of arbitrary units of time called a ``tim
     >>> video.time_base
     Fraction(1, 25)
 
-    >>> video.codec_context.time_base
-    Fraction(1, 50)
-
 Attributes that represent time on those objects will be in that object's ``time_base``:
 
 .. doctest::

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,3 +1,5 @@
+from fractions import Fraction
+
 import av
 
 from .common import TestCase, fate_suite
@@ -59,9 +61,8 @@ class TestDecode(TestCase):
 
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
         stream = container.streams.video[0]
-        codec_context = stream.codec_context
 
-        self.assertNotEqual(stream.time_base, codec_context.time_base)
+        self.assertEqual(stream.time_base, Fraction(1, 25))
 
         for packet in container.demux(stream):
             for frame in packet.decode():


### PR DESCRIPTION
The FFmpeg API docs state that using AVCodecContext.time_base for
decoders is deprecated and AVCodecContext.framerate should be used
instead.