### PR TITLE
Add FFmpeg licensing information

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -26,5 +26,5 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------------------------------------------------------------------------------
 
 FFmpeg that is redistributed within all PyAV wheels and binaries is licensed
-under GNU General Public License (GPL) version 2 or later. If those binaries
-are used, this license applies to all of PyAV. 
+under their respective license outlined below:
+http://ffmpeg.org/legal.html

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -21,3 +21,10 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------
+
+FFmpeg that is redistributed within all PyAV wheels and binaries is licensed
+under GNU General Public License (GPL) version 2 or later. If those binaries
+are used, this license applies to all of PyAV. 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ pip install --upgrade -r tests/requirements.txt
 make
 ```
 
+Licensing
+----------
+
+PyAV python package is available under [BSD3 license](LICENSE.txt).
+[PyPI][pypi] and [conda-forge][conda-forge] binaries are shipped with FFmpeg
+binaries under GPLv2 or later.
+
+
 ---
 
 Have fun, [read the docs][docs], [come chat with us][gitter], and good luck!

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Licensing
 ----------
 
 PyAV python package is available under [BSD3 license](LICENSE.txt).
-[PyPI][pypi] and [conda-forge][conda-forge] binaries are shipped with FFmpeg
-binaries under GPLv2 or later.
+[PyPI][pypi] binaries are shipped with FFmpeg
+binaries under their respective [license](http://ffmpeg.org/legal.html). 
 
 
 ---


### PR DESCRIPTION
Per #805, I've added licensing information to `LICENSE.txt` and (perhaps unnecessary) to `README.md`.
The information added to `README.md` would be useful to have in PyPI and conda-forge pages, but I'm unsure on how to add this.