### PR TITLE
Fix useful_array when unaligned and dtype > 1 byte

### DIFF
--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -66,10 +66,10 @@ cdef useful_array(VideoPlane plane, unsigned int bytes_per_pixel=1, str dtype='u
     import numpy as np
     cdef size_t total_line_size = abs(plane.line_size)
     cdef size_t useful_line_size = plane.width * bytes_per_pixel
-    arr = np.frombuffer(plane, np.dtype(dtype))
+    arr = np.frombuffer(plane, np.uint8)
     if total_line_size != useful_line_size:
         arr = arr.reshape(-1, total_line_size)[:, 0:useful_line_size].reshape(-1)
-    return arr
+    return arr.view(np.dtype(dtype))
 
 
 cdef class VideoFrame(Frame):

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -291,6 +291,17 @@ class TestVideoFrameNdarray(TestCase):
         # check endianness by examining red value of first pixel
         self.assertPixelValue16(frame.planes[0], array[0][0][0], "little")
 
+    def test_ndarray_rgb48le_align(self):
+        array = numpy.random.randint(0, 65536, size=(238, 318, 3), dtype=numpy.uint16)
+        frame = VideoFrame.from_ndarray(array, format="rgb48le")
+        self.assertEqual(frame.width, 318)
+        self.assertEqual(frame.height, 238)
+        self.assertEqual(frame.format.name, "rgb48le")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # check endianness by examining red value of first pixel
+        self.assertPixelValue16(frame.planes[0], array[0][0][0], "little")
+
     def test_ndarray_rgba64be(self):
         array = numpy.random.randint(0, 65536, size=(480, 640, 4), dtype=numpy.uint16)
         frame = VideoFrame.from_ndarray(array, format="rgba64be")


### PR DESCRIPTION
This fix the function useful_array when unaligned and dtype's size is 2 or more bytes. See the added test that fails with previous' function.

The issue is that the current fonction crops the numpy array using sizes in bytes instead of in number of array elements. When dtype is not a byte, the wrong cropping occurs.

There are several way to fix the function, such as expressing `total_line_size` and `useful_line_size` in number of elements instead of bytes. I choose to crop the numpy array in bytes before reinterpreting it in `dtype`.