### PR TITLE
Add support in VideoFrame ndarray for gbrp formats

### DIFF
--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -207,6 +207,94 @@ class TestVideoFrameNdarray(TestCase):
             self.assertEqual(frame.format.name, format)
             self.assertNdarraysEqual(frame.to_ndarray(), array)
 
+    def test_ndarray_gbrp(self):
+        array = numpy.random.randint(0, 256, size=(480, 640, 3), dtype=numpy.uint8)
+        frame = VideoFrame.from_ndarray(array, format="gbrp")
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, "gbrp")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrp_align(self):
+        array = numpy.random.randint(0, 256, size=(238, 318, 3), dtype=numpy.uint8)
+        frame = VideoFrame.from_ndarray(array, format="gbrp")
+        self.assertEqual(frame.width, 318)
+        self.assertEqual(frame.height, 238)
+        self.assertEqual(frame.format.name, "gbrp")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrp10(self):
+        array = numpy.random.randint(0, 1024, size=(480, 640, 3), dtype=numpy.uint16)
+        for format in ["gbrp10be", "gbrp10le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 640)
+            self.assertEqual(frame.height, 480)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrp10_align(self):
+        array = numpy.random.randint(0, 1024, size=(238, 318, 3), dtype=numpy.uint16)
+        for format in ["gbrp10be", "gbrp10le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 318)
+            self.assertEqual(frame.height, 238)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrp12(self):
+        array = numpy.random.randint(0, 4096, size=(480, 640, 3), dtype=numpy.uint16)
+        for format in ["gbrp12be", "gbrp12le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 640)
+            self.assertEqual(frame.height, 480)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrp12_align(self):
+        array = numpy.random.randint(0, 4096, size=(238, 318, 3), dtype=numpy.uint16)
+        for format in ["gbrp12be", "gbrp12le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 318)
+            self.assertEqual(frame.height, 238)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrp14(self):
+        array = numpy.random.randint(0, 16384, size=(480, 640, 3), dtype=numpy.uint16)
+        for format in ["gbrp14be", "gbrp14le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 640)
+            self.assertEqual(frame.height, 480)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrp14_align(self):
+        array = numpy.random.randint(0, 16384, size=(238, 318, 3), dtype=numpy.uint16)
+        for format in ["gbrp14be", "gbrp14le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 318)
+            self.assertEqual(frame.height, 238)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrp16(self):
+        array = numpy.random.randint(0, 65536, size=(480, 640, 3), dtype=numpy.uint16)
+        for format in ["gbrp16be", "gbrp16le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 640)
+            self.assertEqual(frame.height, 480)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrp16_align(self):
+        array = numpy.random.randint(0, 65536, size=(238, 318, 3), dtype=numpy.uint16)
+        for format in ["gbrp16be", "gbrp16le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 318)
+            self.assertEqual(frame.height, 238)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
     def test_ndarray_yuv420p(self):
         array = numpy.random.randint(0, 256, size=(720, 640), dtype=numpy.uint8)
         frame = VideoFrame.from_ndarray(array, format="yuv420p")


### PR DESCRIPTION
This adds support for gbrp, gbrp10le, gbrp12le, gbrp14le, gbrp16le and their big-endian counterpart formats.

If this PR is ok, I will also add support in the near future for yuv444p, yuv422p and gbrp32f formats.

This can be tested using the following script (doesn't work for 14 & 16 bits)

```python
import numpy as np
import av


WIDTH = 1920
HEIGHT = 1080
BIT_DEPTH = 12

if BIT_DEPTH == 8:
    pix_fmt = "gbrp"
    dtype = np.uint8
else:
    pix_fmt = f"gbrp{BIT_DEPTH}le"
    dtype = np.uint16

ocntnr = av.open("test.mp4", "w")
ovstrm = ocntnr.add_stream("av1")
ovstrm.width = WIDTH
ovstrm.height = HEIGHT
ovstrm.pix_fmt = pix_fmt

max = 2**BIT_DEPTH - 1
gradient = np.repeat(np.arange(WIDTH) / WIDTH, 3)
h = np.round(np.linspace(0, HEIGHT, 9, endpoint=True)).astype(np.uint32)

colours = [
    [max, max, max],  # White
    [max, 0, 0],  # Red
    [0, max, 0],  # Green
    [0, 0, max],  # Blue
    [max, max, 0],  # Yellow
    [max, 0, max],  # Magenta
    [0, max, max],  # Cyan
    [0, 0, 0],  # Black
]

array = np.empty((HEIGHT, WIDTH, 3), dtype=dtype)
for idx, colour in enumerate(colours):
    array[h[idx] : h[idx + 1], :, :] = (gradient * np.tile(np.array(colour, dtype=dtype), WIDTH)).reshape(WIDTH, -1)

frame = av.VideoFrame.from_ndarray(array, pix_fmt)
for p in ovstrm.encode(frame):
    ocntnr.mux(p)

for p in ovstrm.encode():
    ocntnr.mux(p)

ocntnr.close()

```