### PR TITLE
Use pad count in alloc_filter_pads

### DIFF
--- a/av/filter/pad.pyx
+++ b/av/filter/pad.pyx
@@ -80,10 +80,16 @@ cdef tuple alloc_filter_pads(Filter filter, const lib.AVFilterPad *ptr, bint is_
     # We need to be careful and check our bounds if we know what they are,
     # since the arrays on a AVFilterContext are not NULL terminated.
     cdef int i = 0
-    cdef int count = (context.ptr.nb_inputs if is_input else context.ptr.nb_outputs) if context is not None else -1
+    cdef int count
+    if context is None:
+        # This is a custom function defined using a macro in avfilter.pxd. Its usage
+        # can be changed after we stop supporting FFmpeg < 5.0.
+        count = lib.pyav_get_num_pads(filter.ptr, not is_input, ptr)
+    else:
+        count = (context.ptr.nb_inputs if is_input else context.ptr.nb_outputs)
 
     cdef FilterPad pad
-    while (i < count or count < 0) and lib.avfilter_pad_get_name(ptr, i):
+    while (i < count):
         pad = FilterPad(_cinit_sentinel) if context is None else FilterContextPad(_cinit_sentinel)
         pads.append(pad)
         pad.filter = filter

--- a/include/libavfilter/avfilter.pxd
+++ b/include/libavfilter/avfilter.pxd
@@ -1,6 +1,14 @@
 
 cdef extern from "libavfilter/avfilter.h" nogil:
-
+    """
+    #if (LIBAVFILTER_VERSION_INT >= 525156)
+        // avfilter_filter_pad_count is available since version 8.3.100 of libavfilter (FFmpeg 5.0)
+        #define _avfilter_get_num_pads(filter, is_output, pads) (avfilter_filter_pad_count(filter, is_output))
+    #else
+        // avfilter_filter_pad_count has been deprecated as of version 8.3.100 of libavfilter (FFmpeg 5.0)
+        #define _avfilter_get_num_pads(filter, is_output, pads) (avfilter_pad_count(pads))
+    #endif
+    """
     cdef int   avfilter_version()
     cdef char* avfilter_configuration()
     cdef char* avfilter_license()
@@ -11,6 +19,8 @@ cdef extern from "libavfilter/avfilter.h" nogil:
 
     const char* avfilter_pad_get_name(const AVFilterPad *pads, int index)
     AVMediaType avfilter_pad_get_type(const AVFilterPad *pads, int index)
+
+    int pyav_get_num_pads "_avfilter_get_num_pads" (const AVFilter *filter, int is_output, const AVFilterPad *pads)
 
     cdef struct AVFilter:
 


### PR DESCRIPTION
It doesn't seem safe to rely on the return value of `lib.avfilter_pad_get_name()` to iterate. The docs say that it is up to the caller to ensure the index is valid: https://ffmpeg.org/doxygen/trunk/group__lavfi.html#ga2d69631bb24a0a2b7ac0e00fe1dfab3b This seemed to be causing some spurious test errors on some platforms.
Before libavfilter 8.3.100 (ffmpeg < 5.0), the function to use to get the filter count was `avfilter_pad_count`, but that is now deprecated. We can now use either `avfilter_filter_pad_count` or use the `AVFilter.nb_input` (output) fields directly. See https://ffmpeg.org/pipermail/ffmpeg-cvslog/2021-August/128485.html