### PR TITLE
Add rate and framerate properties to VideoStream (fixes: #1005)

### DIFF
--- a/av/video/stream.pyx
+++ b/av/video/stream.pyx
@@ -1,3 +1,6 @@
+from av.utils cimport avrational_to_fraction
+
+
 cdef class VideoStream(Stream):
 
     def __repr__(self):
@@ -10,3 +13,19 @@ cdef class VideoStream(Stream):
             self.codec_context.height,
             id(self),
         )
+
+    property rate:
+        """
+        Returns the average_frame_rate of the stream.
+        :type: :class:`~fractions.Fraction` or ``None``
+        """
+        def __get__(self):
+            return avrational_to_fraction(&self.ptr.avg_frame_rate)
+
+    property framerate:
+        """
+        Returns the average_frame_rate of the stream.
+        :type: :class:`~fractions.Fraction` or ``None``
+        """
+        def __get__(self):
+            return avrational_to_fraction(&self.ptr.avg_frame_rate)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -121,7 +121,7 @@ def assert_rgb_rotate(self, input_, is_dash=False):
     self.assertEqual(stream.format.name, "yuv420p")
     self.assertEqual(stream.format.width, WIDTH)
     self.assertEqual(stream.format.height, HEIGHT)
-    self.assertEqual(stream.codec_context.rate, None)
+    self.assertEqual(stream.rate, expected_average_rate)
     self.assertEqual(stream.ticks_per_frame, 1)
 
 

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -121,7 +121,7 @@ def assert_rgb_rotate(self, input_, is_dash=False):
     self.assertEqual(stream.format.name, "yuv420p")
     self.assertEqual(stream.format.width, WIDTH)
     self.assertEqual(stream.format.height, HEIGHT)
-    self.assertEqual(stream.rate, None)
+    self.assertEqual(stream.codec_context.rate, None)
     self.assertEqual(stream.ticks_per_frame, 1)
 
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,3 +1,5 @@
+from fractions import Fraction
+
 import av
 
 from .common import TestCase, fate_suite
@@ -25,5 +27,7 @@ class TestStreams(TestCase):
 
         self.assertEqual([video], container.streams.get(video=0))
         self.assertEqual([video], container.streams.get(video=(0,)))
+        self.assertEqual(video.rate, Fraction(25, 1))
+        self.assertEqual(video.framerate, Fraction(25, 1))
 
         # TODO: Find something in the fate suite with video, audio, and subtitles.


### PR DESCRIPTION
Fixes the regression introduced by #910 

This PR fixes the issue by adding properties that point directly to the underlying AVStream's avg_frame_rate. It doesn't set the rate on the new codec_context, but that doesn't appear to be necessary.