### PR TITLE
Add support in VideoFrame ndarray for gbrpf32 format

### DIFF
--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -285,6 +285,12 @@ cdef class VideoFrame(Frame):
             array[:, :, 1] = useful_array(frame.planes[0], 2, "uint16").reshape(-1, frame.width)
             array[:, :, 2] = useful_array(frame.planes[1], 2, "uint16").reshape(-1, frame.width)
             return byteswap_array(array, frame.format.name.endswith('be'))
+        elif frame.format.name in ('gbrpf32be', 'gbrpf32le'):
+            array = np.empty((frame.height, frame.width, 3), dtype="float32")
+            array[:, :, 0] = useful_array(frame.planes[2], 4, "float32").reshape(-1, frame.width)
+            array[:, :, 1] = useful_array(frame.planes[0], 4, "float32").reshape(-1, frame.width)
+            array[:, :, 2] = useful_array(frame.planes[1], 4, "float32").reshape(-1, frame.width)
+            return byteswap_array(array, frame.format.name.endswith('be'))
         elif frame.format.name in ('rgb24', 'bgr24'):
             return useful_array(frame.planes[0], 3).reshape(frame.height, frame.width, -1)
         elif frame.format.name in ('argb', 'rgba', 'abgr', 'bgra'):
@@ -388,6 +394,15 @@ cdef class VideoFrame(Frame):
             copy_array_to_plane(byteswap_array(array[:, :, 1], format.endswith('be')), frame.planes[0], 2)
             copy_array_to_plane(byteswap_array(array[:, :, 2], format.endswith('be')), frame.planes[1], 2)
             copy_array_to_plane(byteswap_array(array[:, :, 0], format.endswith('be')), frame.planes[2], 2)
+            return frame
+        elif format in ('gbrpf32be', 'gbrpf32le'):
+            check_ndarray(array, 'float32', 3)
+            check_ndarray_shape(array, array.shape[2] == 3)
+
+            frame = VideoFrame(array.shape[1], array.shape[0], format)
+            copy_array_to_plane(byteswap_array(array[:, :, 1], format.endswith('be')), frame.planes[0], 4)
+            copy_array_to_plane(byteswap_array(array[:, :, 2], format.endswith('be')), frame.planes[1], 4)
+            copy_array_to_plane(byteswap_array(array[:, :, 0], format.endswith('be')), frame.planes[2], 4)
             return frame
         elif format in ('rgb24', 'bgr24'):
             check_ndarray(array, 'uint8', 3)

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -295,6 +295,24 @@ class TestVideoFrameNdarray(TestCase):
             self.assertEqual(frame.format.name, format)
             self.assertNdarraysEqual(frame.to_ndarray(), array)
 
+    def test_ndarray_gbrpf32(self):
+        array = numpy.random.random_sample(size=(480, 640, 3)).astype(numpy.float32)
+        for format in ["gbrpf32be", "gbrpf32le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 640)
+            self.assertEqual(frame.height, 480)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_ndarray_gbrpf32_align(self):
+        array = numpy.random.random_sample(size=(238, 318, 3)).astype(numpy.float32)
+        for format in ["gbrpf32be", "gbrpf32le"]:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 318)
+            self.assertEqual(frame.height, 238)
+            self.assertEqual(frame.format.name, format)
+            self.assertNdarraysEqual(frame.to_ndarray(), array)
+
     def test_ndarray_yuv420p(self):
         array = numpy.random.randint(0, 256, size=(720, 640), dtype=numpy.uint8)
         frame = VideoFrame.from_ndarray(array, format="yuv420p")


### PR DESCRIPTION
Adds support for floating point RGB format.

Can be tested with this script:

```python
import numpy as np
import av


WIDTH = 1920
HEIGHT = 1080
BIT_DEPTH = 12

if BIT_DEPTH == 8:
    pix_fmt = "gbrp"
    dtype = np.uint8
else:
    pix_fmt = f"gbrp{BIT_DEPTH}le"
    dtype = np.uint16

ocntnr = av.open("test.mp4", "w")
ovstrm = ocntnr.add_stream("av1")
ovstrm.width = WIDTH
ovstrm.height = HEIGHT
ovstrm.pix_fmt = pix_fmt

max = 2**BIT_DEPTH - 1
gradient = np.repeat(np.arange(WIDTH) / WIDTH, 3)
h = np.round(np.linspace(0, HEIGHT, 9, endpoint=True)).astype(np.uint32)

colours = [
    [max, max, max],  # White
    [max, 0, 0],  # Red
    [0, max, 0],  # Green
    [0, 0, max],  # Blue
    [max, max, 0],  # Yellow
    [max, 0, max],  # Magenta
    [0, max, max],  # Cyan
    [0, 0, 0],  # Black
]

array = np.empty((HEIGHT, WIDTH, 3), dtype=dtype)
for idx, colour in enumerate(colours):
    array[h[idx] : h[idx + 1], :, :] = (gradient * np.tile(np.array(colour, dtype=dtype), WIDTH)).reshape(WIDTH, -1)

frame = av.VideoFrame.from_ndarray(array, pix_fmt)
for p in ovstrm.encode(frame):
    ocntnr.mux(p)

for p in ovstrm.encode():
    ocntnr.mux(p)

ocntnr.close()
```