### PR TITLE
[package] advertise Python 3.11 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -214,6 +214,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Multimedia :: Sound/Audio",
         "Topic :: Multimedia :: Sound/Audio :: Conversion",


### PR DESCRIPTION
cibuildwheel v2.10.0 and later will automatically build wheels for Python 3.11.