### PR TITLE
Remove extraneous rate attributes

### DIFF
--- a/av/audio/codeccontext.pyx
+++ b/av/audio/codeccontext.pyx
@@ -75,14 +75,6 @@ cdef class AudioCodecContext(CodecContext):
         def __set__(self, int value):
             self.ptr.sample_rate = value
 
-    property rate:
-        """Another name for :attr:`sample_rate`."""
-        def __get__(self):
-            return self.sample_rate
-
-        def __set__(self, value):
-            self.sample_rate = value
-
     # TODO: Integrate into AudioLayout.
     property channels:
         def __get__(self):

--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -165,14 +165,6 @@ cdef class AudioFrame(Frame):
         def __set__(self, value):
             self.ptr.sample_rate = value
 
-    property rate:
-        """Another name for :attr:`sample_rate`."""
-        def __get__(self):
-            return self.ptr.sample_rate
-
-        def __set__(self, value):
-            self.ptr.sample_rate = value
-
     def to_ndarray(self, **kwargs):
         """Get a numpy array of this frame.
 

--- a/av/audio/resampler.pyx
+++ b/av/audio/resampler.pyx
@@ -94,7 +94,7 @@ cdef class AudioResampler(object):
             if (
                 frame.format.sample_fmt != self.template.format.sample_fmt or
                 frame.layout.layout != self.template.layout.layout or
-                frame.sample_rate != self.template.rate
+                frame.sample_rate != self.template.sample_rate
             ):
                 raise ValueError('Frame does not match AudioResampler setup.')
 

--- a/av/audio/stream.pyx
+++ b/av/audio/stream.pyx
@@ -5,7 +5,7 @@ cdef class AudioStream(Stream):
             self.__class__.__name__,
             self.index,
             self.name,
-            self.rate,
+            self.sample_rate,
             self.layout.name,
             self.format.name if self.format else None,
             id(self),

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -118,14 +118,6 @@ cdef class VideoCodecContext(CodecContext):
         def __set__(self, value):
             to_avrational(value, &self.ptr.framerate)
 
-    property rate:
-        """Another name for :attr:`framerate`."""
-        def __get__(self):
-            return self.framerate
-
-        def __set__(self, value):
-            self.framerate = value
-
     property gop_size:
         def __get__(self):
             return self.ptr.gop_size

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -388,5 +388,5 @@ class TestEncoding(TestCase):
         # so can really use checksums
         for frame in iter_raw_frames(path, packet_sizes, ctx):
             result_samples += frame.samples
-            self.assertEqual(frame.rate, sample_rate)
+            self.assertEqual(frame.sample_rate, sample_rate)
             self.assertEqual(len(frame.layout.channels), channels)

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -53,7 +53,7 @@ class TestDecode(TestCase):
                 sample_count += frame.samples
 
         total_samples = (
-            audio_stream.duration * audio_stream.rate.numerator
+            audio_stream.duration * audio_stream.sample_rate.numerator
         ) / audio_stream.time_base.denominator
         self.assertEqual(sample_count, total_samples)
 

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -121,7 +121,6 @@ def assert_rgb_rotate(self, input_, is_dash=False):
     self.assertEqual(stream.format.name, "yuv420p")
     self.assertEqual(stream.format.width, WIDTH)
     self.assertEqual(stream.format.height, HEIGHT)
-    self.assertEqual(stream.rate, None)
     self.assertEqual(stream.ticks_per_frame, 1)
 
 
@@ -129,13 +128,13 @@ class TestBasicVideoEncoding(TestCase):
     def test_default_options(self):
         with av.open(self.sandboxed("output.mov"), "w") as output:
             stream = output.add_stream("mpeg4")
+            self.assertEqual(stream.average_rate, Fraction(24, 1))
             self.assertEqual(stream.bit_rate, 1024000)
             self.assertEqual(stream.format.height, 480)
             self.assertEqual(stream.format.name, "yuv420p")
             self.assertEqual(stream.format.width, 640)
             self.assertEqual(stream.height, 480)
             self.assertEqual(stream.pix_fmt, "yuv420p")
-            self.assertEqual(stream.rate, Fraction(24, 1))
             self.assertEqual(stream.ticks_per_frame, 1)
             self.assertEqual(stream.time_base, None)
             self.assertEqual(stream.width, 640)
@@ -185,7 +184,7 @@ class TestBasicAudioEncoding(TestCase):
             stream = output.add_stream("mp2")
             self.assertEqual(stream.bit_rate, 128000)
             self.assertEqual(stream.format.name, "s16")
-            self.assertEqual(stream.rate, 48000)
+            self.assertEqual(stream.sample_rate, 48000)
             self.assertEqual(stream.ticks_per_frame, 1)
             self.assertEqual(stream.time_base, None)
 
@@ -262,7 +261,7 @@ class TestEncodeStreamSemantics(TestCase):
                     # decoder didn't indicate constant frame size
                     frame_size = 1000
                 aframe = AudioFrame("s16", "stereo", samples=frame_size)
-                aframe.rate = 48000
+                aframe.sample_rate = 48000
                 apackets = astream.encode(aframe)
                 if apackets:
                     apacket = apackets[0]

--- a/tests/test_file_probing.py
+++ b/tests/test_file_probing.py
@@ -58,7 +58,7 @@ class TestAudioProbe(TestCase):
         self.assertEqual(stream.format.name, "fltp")
         self.assertEqual(stream.layout.name, "stereo")
         self.assertEqual(stream.max_bit_rate, None)
-        self.assertEqual(stream.rate, 48000)
+        self.assertEqual(stream.sample_rate, 48000)
 
 
 class TestAudioProbeCorrupt(TestCase):
@@ -116,7 +116,7 @@ class TestAudioProbeCorrupt(TestCase):
         self.assertEqual(stream.format, None)
         self.assertEqual(stream.layout.name, "0 channels")
         self.assertEqual(stream.max_bit_rate, None)
-        self.assertEqual(stream.rate, 0)
+        self.assertEqual(stream.sample_rate, 0)
 
 
 class TestDataProbe(TestCase):

--- a/tests/test_seek.py
+++ b/tests/test_seek.py
@@ -6,7 +6,7 @@ from .common import TestCase, fate_suite
 
 
 def timestamp_to_frame(timestamp, stream):
-    fps = stream.rate
+    fps = stream.average_rate
     time_base = stream.time_base
     start_time = stream.start_time
     frame = (timestamp - start_time) * float(time_base) * float(fps)
@@ -103,7 +103,7 @@ class TestSeek(TestCase):
 
         # set target frame to middle frame
         target_frame = int(total_frame_count / 2.0)
-        target_timestamp = int((target_frame * av.time_base) / video_stream.rate)
+        target_timestamp = int((target_frame * av.time_base) / video_stream.average_rate)
 
         # should seek to nearest keyframe before target_timestamp
         container.seek(target_timestamp)


### PR DESCRIPTION
This PR removes the following attributes:
AudioCodecContext.rate (use AudioCodecContext.sample_rate instead)
AudioFrame.rate (use AudioFrame.sample_rate instead)
VideoStream.rate and VideoStream.framerate (use VideoStream.average_rate instead)
VideoCodecContext.rate (use VideoCodecContext.framerate instead)
