### PR TITLE
Clarify "rate" properties by deprecating aliases

### DIFF
--- a/av/audio/codeccontext.pyx
+++ b/av/audio/codeccontext.pyx
@@ -1,5 +1,6 @@
 cimport libav as lib
 
+from av import deprecation
 from av.audio.format cimport AudioFormat, get_audio_format
 from av.audio.frame cimport AudioFrame, alloc_audio_frame
 from av.audio.layout cimport AudioLayout, get_audio_layout
@@ -75,13 +76,7 @@ cdef class AudioCodecContext(CodecContext):
         def __set__(self, int value):
             self.ptr.sample_rate = value
 
-    property rate:
-        """Another name for :attr:`sample_rate`."""
-        def __get__(self):
-            return self.sample_rate
-
-        def __set__(self, value):
-            self.sample_rate = value
+    rate = deprecation.renamed_attr("sample_rate")
 
     # TODO: Integrate into AudioLayout.
     property channels:

--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -1,3 +1,4 @@
+from av import deprecation
 from av.audio.format cimport get_audio_format
 from av.audio.layout cimport get_audio_layout
 from av.audio.plane cimport AudioPlane
@@ -165,13 +166,7 @@ cdef class AudioFrame(Frame):
         def __set__(self, value):
             self.ptr.sample_rate = value
 
-    property rate:
-        """Another name for :attr:`sample_rate`."""
-        def __get__(self):
-            return self.ptr.sample_rate
-
-        def __set__(self, value):
-            self.ptr.sample_rate = value
+    rate = deprecation.renamed_attr("sample_rate")
 
     def to_ndarray(self, **kwargs):
         """Get a numpy array of this frame.

--- a/av/audio/resampler.pyx
+++ b/av/audio/resampler.pyx
@@ -94,7 +94,7 @@ cdef class AudioResampler(object):
             if (
                 frame.format.sample_fmt != self.template.format.sample_fmt or
                 frame.layout.layout != self.template.layout.layout or
-                frame.sample_rate != self.template.rate
+                frame.sample_rate != self.template.sample_rate
             ):
                 raise ValueError('Frame does not match AudioResampler setup.')
 

--- a/av/audio/stream.pyx
+++ b/av/audio/stream.pyx
@@ -5,7 +5,7 @@ cdef class AudioStream(Stream):
             self.__class__.__name__,
             self.index,
             self.name,
-            self.rate,
+            self.sample_rate,
             self.layout.name,
             self.format.name if self.format else None,
             id(self),

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -219,7 +219,7 @@ cdef class Stream(object):
         The average frame rate of this video stream.
 
         This is calculated when the file is opened by looking at the first
-        few frames and averaging their rate.
+        few frames and averaging their rate. See :ffmpeg:`AVStream.avg_frame_rate`
 
         :type: :class:`~fractions.Fraction` or ``None``
 

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -1,6 +1,7 @@
 from libc.stdint cimport int64_t
 cimport libav as lib
 
+from av import deprecation
 from av.codec.context cimport CodecContext
 from av.error cimport err_check
 from av.frame cimport Frame
@@ -118,13 +119,7 @@ cdef class VideoCodecContext(CodecContext):
         def __set__(self, value):
             to_avrational(value, &self.ptr.framerate)
 
-    property rate:
-        """Another name for :attr:`framerate`."""
-        def __get__(self):
-            return self.framerate
-
-        def __set__(self, value):
-            self.framerate = value
+    rate = deprecation.renamed_attr("framerate")
 
     property gop_size:
         def __get__(self):


### PR DESCRIPTION
We have multiple properties referring to "rates", some of which go by a generic "rate" name without specifying whether it is a frame rate or a sample rate.

This change deprecates:

- `AudioCodecContext.rate` (use `AudioCodecContext.sample_rate`)
- `AudioFrame.rate` (use `AudioFrame.sample_rate`)
- `VideoCodecContext.rate` (use `VideoCodecContext.framerate`)