### PR TITLE
Deprecate Stream.framerate passthrough

### DIFF
--- a/tests/test_file_probing.py
+++ b/tests/test_file_probing.py
@@ -1,4 +1,5 @@
 from fractions import Fraction
+import warnings
 
 import av
 
@@ -318,6 +319,20 @@ class TestVideoProbe(TestCase):
         # confirm.
         self.assertIn(stream.coded_width, (720, 0))
         self.assertIn(stream.coded_height, (576, 0))
+
+        # Deprecated properties.
+        with warnings.catch_warnings(record=True) as captured:
+            self.assertIsNone(stream.framerate)
+            self.assertEqual(
+                captured[0].message.args[0],
+                "VideoStream.framerate is deprecated as it is not always set; please use VideoStream.average_rate.",
+            )
+        with warnings.catch_warnings(record=True) as captured:
+            self.assertIsNone(stream.rate)
+            self.assertEqual(
+                captured[0].message.args[0],
+                "VideoStream.rate is deprecated as it is not always set; please use VideoStream.average_rate.",
+            )
 
 
 class TestVideoProbeCorrupt(TestCase):


### PR DESCRIPTION
See https://github.com/PyAV-Org/PyAV/issues/1005
Since the behavior of `VideoStream.framerate` has changed, this PR disallows passthrough of that attribute so that users will be forced to switch to `VideoStream.average_rate`