### PR TITLE
[package] compile wheels against FFmpeg 5.1.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest, python: 3.7, ffmpeg: "5.0", extras: true}
+          - {os: ubuntu-latest, python: 3.7, ffmpeg: "5.1", extras: true}
+          - {os: ubuntu-latest, python: 3.7, ffmpeg: "5.0"}
           - {os: ubuntu-latest, python: 3.7, ffmpeg: "4.4"}
           - {os: ubuntu-latest, python: 3.7, ffmpeg: "4.3"}
           - {os: ubuntu-latest, python: pypy3, ffmpeg: "4.4"}
@@ -146,6 +147,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: windows-latest, python: 3.7, ffmpeg: "5.1"}
           - {os: windows-latest, python: 3.7, ffmpeg: "5.0"}
           - {os: windows-latest, python: 3.7, ffmpeg: "4.4"}
           - {os: windows-latest, python: 3.7, ffmpeg: "4.3"}
@@ -167,7 +169,9 @@ jobs:
           pillow \
           python=${{ matrix.config.python }} \
           setuptools
-          if [[ "${{ matrix.config.ffmpeg }}" == "5.0" ]]; then
+          if [[ "${{ matrix.config.ffmpeg }}" == "5.1" ]]; then
+            curl -L -o ffmpeg.tar.gz https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.1.2-1/ffmpeg-win_amd64.tar.gz
+          elif [[ "${{ matrix.config.ffmpeg }}" == "5.0" ]]; then
             curl -L -o ffmpeg.tar.gz https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.0.1-1/ffmpeg-win_amd64.tar.gz
           elif [[ "${{ matrix.config.ffmpeg }}" == "4.4" ]]; then
             curl -L -o ffmpeg.tar.gz https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/4.4.1-8/ffmpeg-win_amd64.tar.gz

--- a/docs/overview/installation.rst
+++ b/docs/overview/installation.rst
@@ -11,11 +11,10 @@ Since release 8.0.0 binary wheels are provided on PyPI for Linux, Mac and Window
     pip install av
 
 
-Currently FFmpeg 4.4.1 is used with the following features enabled for all platforms:
+Currently FFmpeg 5.1.2 is used with the following features enabled for all platforms:
 
 - fontconfig
 - gmp
-- gnutls
 - libaom
 - libass
 - libbluray
@@ -37,6 +36,11 @@ Currently FFmpeg 4.4.1 is used with the following features enabled for all platf
 - libxvid
 - lzma
 - zlib
+
+The following additional features are also enabled on Linux:
+
+- gnutls
+- libxcb
 
 
 Conda

--- a/scripts/fetch-vendor.json
+++ b/scripts/fetch-vendor.json
@@ -1,3 +1,3 @@
 {
-    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.0.1-1/ffmpeg-{platform}.tar.gz"]
+    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.1.2-1/ffmpeg-{platform}.tar.gz"]
 }


### PR DESCRIPTION
We also update our test matrix to explicitly test against FFmpeg 5.1.