### PR TITLE
[tests] update all github actions to latest version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout
 
       - name: Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -60,7 +60,7 @@ jobs:
           - {os: ubuntu-latest, python: 3.7, ffmpeg: "5.0"}
           - {os: ubuntu-latest, python: 3.7, ffmpeg: "4.4"}
           - {os: ubuntu-latest, python: 3.7, ffmpeg: "4.3"}
-          - {os: ubuntu-latest, python: pypy3, ffmpeg: "4.4"}
+          - {os: ubuntu-latest, python: pypy3.9, ffmpeg: "4.4"}
           - {os: macos-latest,  python: 3.7, ffmpeg: "4.4"}
 
     env:
@@ -69,11 +69,11 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout
 
     - name: Python ${{ matrix.config.python }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config.python }}
 
@@ -155,7 +155,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Conda
       shell: bash
@@ -199,8 +199,8 @@ jobs:
   package-source:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Build source package
@@ -209,7 +209,7 @@ jobs:
           python scripts/fetch-vendor.py /tmp/vendor
           PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig python setup.py sdist
       - name: Upload source package
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/
@@ -233,13 +233,13 @@ jobs:
           - os: windows-latest
             arch: AMD64
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Set up QEMU
         if: matrix.os == 'ubuntu-latest'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Install packages
         if: matrix.os == 'macos-latest'
         run: |
@@ -265,7 +265,7 @@ jobs:
           cibuildwheel --output-dir dist
         shell: bash
       - name: Upload wheels
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/
@@ -274,8 +274,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [package-source, package-wheel]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
This should get rid of the warnings related to Node.js 12 actions.