### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ import shlex
 import subprocess
 import sys
 
+from setuptools import Extension, find_packages, setup
 from Cython.Build import cythonize
 from Cython.Compiler.AutoDocTransforms import EmbedSignature
-from setuptools import Extension, find_packages, setup
 
 
 FFMPEG_LIBRARIES = [


### PR DESCRIPTION
setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

In this case, the Cython imports import distutils, so we need to pre-empt that.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

Fixes: https://bugs.debian.org/1022472