### PR TITLE
Remove unecessary clip in numpy example

### DIFF
--- a/examples/numpy/generate_video.py
+++ b/examples/numpy/generate_video.py
@@ -22,7 +22,6 @@ for frame_i in range(total_frames):
     img[:, :, 2] = 0.5 + 0.5 * np.sin(2 * np.pi * (2 / 3 + frame_i / total_frames))
 
     img = np.round(255 * img).astype(np.uint8)
-    img = np.clip(img, 0, 255)
 
     frame = av.VideoFrame.from_ndarray(img, format="rgb24")
     for packet in stream.encode(frame):


### PR DESCRIPTION
By the time you got to that line, the number is already a uint8, and cannot take any values outside of 0, 255.