### PR TITLE
Add python_requires to help users not install this with python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ setup(
     url="https://github.com/PyAV-Org/PyAV",
     packages=find_packages(exclude=["build*", "examples*", "scratchpad*", "tests*"]),
     package_data=package_data,
+    python_requires='>=3.7',
     zip_safe=False,
     ext_modules=ext_modules,
     test_suite="tests",


### PR DESCRIPTION
Works toward https://github.com/PyAV-Org/PyAV/issues/1057

You might need to yank the release and release 10.0.1