### PR TITLE
Create a path toward sharing memory from a numpy buffer

### DIFF
--- a/av/video/frame.pxd
+++ b/av/video/frame.pxd
@@ -11,6 +11,7 @@ cdef class VideoFrame(Frame):
     # This is the buffer that is used to back everything in the AVFrame.
     # We don't ever actually access it directly.
     cdef uint8_t *_buffer
+    cdef object _np_buffer
 
     cdef VideoReformatter reformatter
 

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -381,24 +381,24 @@ cdef class VideoFrame(Frame):
         return frame
 
     @staticmethod
-    def from_numpy_buffer(array, format='rgb24'):
-        if format in ["rgb24", "bgr24"]:
+    def from_numpy_buffer(array, format="rgb24"):
+        if format in ("rgb24", "bgr24"):
             check_ndarray(array, 'uint8', 3)
             check_ndarray_shape(array, array.shape[2] == 3)
             height, width = array.shape[:2]
-        elif format in ('gray', 'gray8', 'rgb8', 'bgr8'):
-            check_ndarray(array, 'uint8', 2)
+        elif format in ("gray", "gray8", "rgb8", "bgr8"):
+            check_ndarray(array, "uint8", 2)
             height, width = array.shape[:2]
-        elif format in ["yuv420p", "yuvj420p", "nv12"]:
-            check_ndarray(array, 'uint8', 2)
+        elif format in ("yuv420p", "yuvj420p", "nv12"):
+            check_ndarray(array, "uint8", 2)
             check_ndarray_shape(array, array.shape[0] % 3 == 0)
             check_ndarray_shape(array, array.shape[1] % 2 == 0)
             height, width = array.shape[:2]
             height = height // 6 * 4
         else:
-            raise ValueError('Conversion from numpy array with format `%s` is not yet supported' % format)
+            raise ValueError(f"Conversion from numpy array with format `{format}` is not yet supported")
 
-        if not array.flags['C_CONTIGUOUS']:
+        if not array.flags["C_CONTIGUOUS"]:
             raise ValueError("provided array must be C_CONTIGUOUS")
 
         frame = alloc_video_frame()

--- a/av/video/plane.pxd
+++ b/av/video/plane.pxd
@@ -6,3 +6,7 @@ cdef class VideoPlane(Plane):
 
     cdef readonly size_t buffer_size
     cdef readonly unsigned int width, height
+
+
+cdef class YUVPlanes(VideoPlane):
+    pass

--- a/av/video/plane.pyx
+++ b/av/video/plane.pyx
@@ -37,3 +37,20 @@ cdef class VideoPlane(Plane):
         """
         def __get__(self):
             return self.frame.ptr.linesize[self.index]
+
+
+cdef class YUVPlanes(VideoPlane):
+    def __cinit__(self, VideoFrame frame, int index):
+        if index != 0:
+            raise RuntimeError("YUVPlanes only supports index 0")
+        if frame.format.name not in ['yuvj420p', 'yuv420p']:
+            raise RuntimeError("YUVPlane only supports yuv420p and yuvj420p")
+        if frame.ptr.linesize[0] < 0:
+            raise RuntimeError("YUVPlane only supports positive linesize")
+        self.width = frame.width
+        self.height = frame.height * 3 // 2
+        self.buffer_size = self.height *  abs(self.frame.ptr.linesize[0])
+        self.frame = frame
+
+    cdef void* _buffer_ptr(self):
+        return self.frame.ptr.extended_data[self.index]

--- a/av/video/plane.pyx
+++ b/av/video/plane.pyx
@@ -2,11 +2,9 @@ from av.video.frame cimport VideoFrame
 
 
 cdef class VideoPlane(Plane):
-
     def __cinit__(self, VideoFrame frame, int index):
-
         # The palette plane has no associated component or linesize; set fields manually
-        if frame.format.name == 'pal8' and index == 1:
+        if frame.format.name == "pal8" and index == 1:
             self.width = 256
             self.height = 1
             self.buffer_size = 256 * 4
@@ -19,7 +17,7 @@ cdef class VideoPlane(Plane):
                 self.height = component.height
                 break
         else:
-            raise RuntimeError('could not find plane %d of %r' % (index, frame.format))
+            raise RuntimeError("could not find plane %d of %r" % (index, frame.format))
 
         # Sometimes, linesize is negative (and that is meaningful). We are only
         # insisting that the buffer size be based on the extent of linesize, and
@@ -43,7 +41,7 @@ cdef class YUVPlanes(VideoPlane):
     def __cinit__(self, VideoFrame frame, int index):
         if index != 0:
             raise RuntimeError("YUVPlanes only supports index 0")
-        if frame.format.name not in ['yuvj420p', 'yuv420p']:
+        if frame.format.name not in ("yuvj420p", "yuv420p"):
             raise RuntimeError("YUVPlane only supports yuv420p and yuvj420p")
         if frame.ptr.linesize[0] < 0:
             raise RuntimeError("YUVPlane only supports positive linesize")

--- a/include/libavutil/avutil.pxd
+++ b/include/libavutil/avutil.pxd
@@ -297,6 +297,18 @@ cdef extern from "libavutil/imgutils.h" nogil:
         AVPixelFormat pix_fmt,
         int align
     )
+    cdef int av_image_fill_pointers(
+        uint8_t *pointers[4],
+        AVPixelFormat pix_fmt,
+        int height,
+        uint8_t *ptr,
+        const int linesizes[4]
+    )
+    cdef int av_image_fill_linesizes(
+        int linesizes[4],
+        AVPixelFormat pix_fmt,
+        int width,
+    )
 
 
 cdef extern from "libavutil/log.h" nogil:

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -491,6 +491,104 @@ class TestVideoFrameNdarray(TestCase):
         self.assertNdarraysEqual(frame.to_ndarray(), array)
 
 
+class TestVideoFrameNumpyBuffer(TestCase):
+    def test_shares_memory_gray(self):
+        array = numpy.random.randint(0, 256, size=(357, 318), dtype=numpy.uint8)
+        frame = VideoFrame.from_numpy_buffer(array, "gray")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # overwrite the array, the contents thereof
+        array[...] = numpy.random.randint(0, 256, size=(357, 318), dtype=numpy.uint8)
+        # Make sure the frame reflects that
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_shares_memory_gray8(self):
+        array = numpy.random.randint(0, 256, size=(357, 318), dtype=numpy.uint8)
+        frame = VideoFrame.from_numpy_buffer(array, "gray8")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # overwrite the array, the contents thereof
+        array[...] = numpy.random.randint(0, 256, size=(357, 318), dtype=numpy.uint8)
+        # Make sure the frame reflects that
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_shares_memory_rgb8(self):
+        array = numpy.random.randint(0, 256, size=(357, 318), dtype=numpy.uint8)
+        frame = VideoFrame.from_numpy_buffer(array, "rgb8")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # overwrite the array, the contents thereof
+        array[...] = numpy.random.randint(0, 256, size=(357, 318), dtype=numpy.uint8)
+        # Make sure the frame reflects that
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_shares_memory_bgr8(self):
+        array = numpy.random.randint(0, 256, size=(357, 318), dtype=numpy.uint8)
+        frame = VideoFrame.from_numpy_buffer(array, "bgr8")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # overwrite the array, the contents thereof
+        array[...] = numpy.random.randint(0, 256, size=(357, 318), dtype=numpy.uint8)
+        # Make sure the frame reflects that
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_shares_memory_rgb24(self):
+        array = numpy.random.randint(0, 256, size=(357, 318, 3), dtype=numpy.uint8)
+        frame = VideoFrame.from_numpy_buffer(array, "rgb24")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # overwrite the array, the contents thereof
+        array[...] = numpy.random.randint(0, 256, size=(357, 318, 3), dtype=numpy.uint8)
+        # Make sure the frame reflects that
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_shares_memory_yuv420p(self):
+        array = numpy.random.randint(
+            0, 256, size=(512 * 6 // 4, 256), dtype=numpy.uint8
+        )
+        frame = VideoFrame.from_numpy_buffer(array, "yuv420p")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # overwrite the array, the contents thereof
+        array[...] = numpy.random.randint(0, 256, size=array.shape, dtype=numpy.uint8)
+        # Make sure the frame reflects that
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_shares_memory_yuvj420p(self):
+        array = numpy.random.randint(
+            0, 256, size=(512 * 6 // 4, 256), dtype=numpy.uint8
+        )
+        frame = VideoFrame.from_numpy_buffer(array, "yuvj420p")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # overwrite the array, the contents thereof
+        array[...] = numpy.random.randint(0, 256, size=array.shape, dtype=numpy.uint8)
+        # Make sure the frame reflects that
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_shares_memory_nv12(self):
+        array = numpy.random.randint(
+            0, 256, size=(512 * 6 // 4, 256), dtype=numpy.uint8
+        )
+        frame = VideoFrame.from_numpy_buffer(array, "nv12")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # overwrite the array, the contents thereof
+        array[...] = numpy.random.randint(0, 256, size=array.shape, dtype=numpy.uint8)
+        # Make sure the frame reflects that
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+    def test_shares_memory_bgr24(self):
+        array = numpy.random.randint(0, 256, size=(357, 318, 3), dtype=numpy.uint8)
+        frame = VideoFrame.from_numpy_buffer(array, "bgr24")
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+        # overwrite the array, the contents thereof
+        array[...] = numpy.random.randint(0, 256, size=(357, 318, 3), dtype=numpy.uint8)
+        # Make sure the frame reflects that
+        self.assertNdarraysEqual(frame.to_ndarray(), array)
+
+
 class TestVideoFrameTiming(TestCase):
     def test_reformat_pts(self):
         frame = VideoFrame(640, 480, "rgb24")


### PR DESCRIPTION
I know there is some concern about having the memory aligned.

I didn't know if it needed to be aligned to 16 bits, or 16 bytes.

If you know let me know which it is, I can add a check for it. If you don't want to support this, then that is fine too.

Closes: https://github.com/PyAV-Org/PyAV/issues/1060