### PR TITLE
[streams] populate added stream with codec param (fixes #1044)

### DIFF
--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -116,6 +116,12 @@ cdef class OutputContainer(Container):
         if self.ptr.oformat.flags & lib.AVFMT_GLOBALHEADER:
             codec_context.flags |= lib.AV_CODEC_FLAG_GLOBAL_HEADER
 
+        # Initialise stream codec parameters to populate the codec type.
+        #
+        # Subsequent changes to the codec context will be applied just before
+        # encoding starts in `start_encoding()`.
+        err_check(lib.avcodec_parameters_from_context(stream.codecpar, codec_context))
+
         # Construct the user-land stream
         cdef CodecContext py_codec_context = wrap_codec_context(codec_context, codec)
         cdef Stream py_stream = wrap_stream(self, stream, py_codec_context)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -126,6 +126,7 @@ class TestBasicVideoEncoding(TestCase):
     def test_default_options(self):
         with av.open(self.sandboxed("output.mov"), "w") as output:
             stream = output.add_stream("mpeg4")
+            self.assertIn(stream, output.streams.video)
             self.assertEqual(stream.average_rate, Fraction(24, 1))
             self.assertEqual(stream.time_base, None)
 
@@ -152,6 +153,7 @@ class TestBasicVideoEncoding(TestCase):
 
         with av.open(path, "w") as output:
             stream = output.add_stream("libx264", 24)
+            self.assertIn(stream, output.streams.video)
             stream.width = WIDTH
             stream.height = HEIGHT
             stream.pix_fmt = "yuv420p"
@@ -182,6 +184,7 @@ class TestBasicAudioEncoding(TestCase):
     def test_default_options(self):
         with av.open(self.sandboxed("output.mov"), "w") as output:
             stream = output.add_stream("mp2")
+            self.assertIn(stream, output.streams.audio)
             self.assertEqual(stream.time_base, None)
 
             # codec context properties
@@ -203,6 +206,7 @@ class TestBasicAudioEncoding(TestCase):
             sample_fmt = "s16"
 
             stream = output.add_stream("mp2", sample_rate)
+            self.assertIn(stream, output.streams.audio)
 
             ctx = stream.codec_context
             ctx.time_base = sample_rate
@@ -241,11 +245,13 @@ class TestEncodeStreamSemantics(TestCase):
     def test_stream_index(self):
         with av.open(self.sandboxed("output.mov"), "w") as output:
             vstream = output.add_stream("mpeg4", 24)
+            self.assertIn(vstream, output.streams.video)
             vstream.pix_fmt = "yuv420p"
             vstream.width = 320
             vstream.height = 240
 
             astream = output.add_stream("mp2", 48000)
+            self.assertIn(astream, output.streams.audio)
             astream.channels = 2
             astream.format = "s16"
 
@@ -277,6 +283,7 @@ class TestEncodeStreamSemantics(TestCase):
     def test_set_id_and_time_base(self):
         with av.open(self.sandboxed("output.mov"), "w") as output:
             stream = output.add_stream("mp2")
+            self.assertIn(stream, output.streams.audio)
 
             # set id
             self.assertEqual(stream.id, 0)


### PR DESCRIPTION
fixes #1044 

avformat_new_stream(AVFormatContext *s, const AVCodec *c) does not use their second parameter [[1]]
So avcodec_parameters_from_context() should do the job [[2]]

[1]: https://ffmpeg.org/doxygen/trunk/group__lavf__core.html#gadcb0fd3e507d9b58fe78f61f8ad39827
[2]: https://ffmpeg.org/doxygen/trunk/codec__par_8c_source.html#l00099