### PR TITLE
more flexibility in the use of 'av.audio.frame.from_ndarray'

### DIFF
--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -117,8 +117,11 @@ cdef class AudioFrame(Frame):
         if format is not None:
             logging.warning('deprecated warning : the `format` argument is ignored')
 
-        # map numpy type to avcodec type
-        format = {np_t: av_t for av_t, np_t in format_dtypes.items()}.get(array.dtype.str[-2:], None)
+        # map numpy type to avcodec non planar type
+        format = (
+            {np_t: av_t for av_t, np_t in format_dtypes.items() if not av_t.endswith('p')}
+            .get(array.dtype.str[-2:], None)
+        )
         if format is None:
             raise ValueError('The numpy array format `%s` is not yet supported' % array.dtype.name)
         if layout is None:
@@ -131,7 +134,7 @@ cdef class AudioFrame(Frame):
         else:
             logging.warning('deprecated warning : the `layout` argument can be deduced from the array shape.')
 
-        # conversion of the shape into an acceptable type
+        # conversion of the shape into a non planar type
         array = np.expand_dims(array.ravel(order='F'), 0)
 
         # check input format

--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -11,16 +11,16 @@ cdef object _cinit_bypass_sentinel
 
 
 format_dtypes = {
-    'dbl': 'float64',
-    'dblp': 'float64',
-    'flt': 'float32',
-    'fltp': 'float32',
-    's16': 'int16',
-    's16p': 'int16',
-    's32': 'int32',
-    's32p': 'int32',
-    'u8': 'uint8',
-    'u8p': 'uint8',
+    'dbl': 'f8', # float64
+    'dblp': 'f8',
+    'flt': 'f4', # float32
+    'fltp': 'f4',
+    's16': 'i2', # int16
+    's16p': 'i2',
+    's32': 'i4', # int32
+    's32p': 'i4',
+    'u8': 'u1', # uint8
+    'u8p': 'u1',
 }
 
 
@@ -118,7 +118,7 @@ cdef class AudioFrame(Frame):
             logging.warning('deprecated warning : the `format` argument is ignored')
 
         # map numpy type to avcodec type
-        format = {np_t: av_t for av_t, np_t in format_dtypes.items()}.get(array.dtype.name, None)
+        format = {np_t: av_t for av_t, np_t in format_dtypes.items()}.get(array.dtype.str[-2:], None)
         if format is None:
             raise ValueError('The numpy array format `%s` is not yet supported' % array.dtype.name)
         if layout is None:

--- a/tests/test_audioframe.py
+++ b/tests/test_audioframe.py
@@ -83,8 +83,6 @@ class TestAudioFrameConveniences(TestCase):
         layouts = [
             ("dbl", "mono", "f8", (1, 160)),
             ("dbl", "stereo", "f8", (2, 160)),
-            ("dblp", "mono", "f8", (1, 160)),
-            ("dblp", "stereo", "f8", (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.ndarray(shape=size, dtype=dtype)
@@ -124,8 +122,6 @@ class TestAudioFrameConveniences(TestCase):
         layouts = [
             ("flt", "mono", "f4", (1, 160)),
             ("flt", "stereo", "f4", (2, 160)),
-            ("fltp", "mono", "f4", (1, 160)),
-            ("fltp", "stereo", "f4", (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.ndarray(shape=size, dtype=dtype)
@@ -141,8 +137,6 @@ class TestAudioFrameConveniences(TestCase):
         layouts = [
             ("s16", "mono", "i2", (1, 160)),
             ("s16", "stereo", "i2", (2, 160)),
-            ("s16p", "mono", "i2", (1, 160)),
-            ("s16p", "stereo", "i2", (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.random.randint(0, 256, size=size, dtype=dtype)
@@ -162,8 +156,6 @@ class TestAudioFrameConveniences(TestCase):
         layouts = [
             ("s32", "mono", "i4", (1, 160)),
             ("s32", "stereo", "i4", (2, 160)),
-            ("s32p", "mono", "i4", (1, 160)),
-            ("s32p", "stereo", "i4", (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.random.randint(0, 256, size=size, dtype=dtype)
@@ -177,8 +169,6 @@ class TestAudioFrameConveniences(TestCase):
         layouts = [
             ("u8", "mono", "u1", (1, 160)),
             ("u8", "stereo", "u1", (2, 160)),
-            ("u8p", "mono", "u1", (1, 160)),
-            ("u8p", "stereo", "u1", (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.random.randint(0, 256, size=size, dtype=dtype)

--- a/tests/test_audioframe.py
+++ b/tests/test_audioframe.py
@@ -82,7 +82,7 @@ class TestAudioFrameConveniences(TestCase):
     def test_ndarray_dbl(self):
         layouts = [
             ("dbl", "mono", "f8", (1, 160)),
-            ("dbl", "stereo", "f8", (1, 320)),
+            ("dbl", "stereo", "f8", (2, 160)),
             ("dblp", "mono", "f8", (1, 160)),
             ("dblp", "stereo", "f8", (2, 160)),
         ]
@@ -90,7 +90,7 @@ class TestAudioFrameConveniences(TestCase):
             array = numpy.ndarray(shape=size, dtype=dtype)
             for i in range(size[0]):
                 array[i][:] = numpy.random.rand(size[1])
-            frame = AudioFrame.from_ndarray(array, format=format, layout=layout)
+            frame = AudioFrame.from_ndarray(array)
             self.assertEqual(frame.format.name, format)
             self.assertEqual(frame.layout.name, layout)
             self.assertEqual(frame.samples, 160)
@@ -123,7 +123,7 @@ class TestAudioFrameConveniences(TestCase):
     def test_ndarray_flt(self):
         layouts = [
             ("flt", "mono", "f4", (1, 160)),
-            ("flt", "stereo", "f4", (1, 320)),
+            ("flt", "stereo", "f4", (2, 160)),
             ("fltp", "mono", "f4", (1, 160)),
             ("fltp", "stereo", "f4", (2, 160)),
         ]
@@ -131,7 +131,7 @@ class TestAudioFrameConveniences(TestCase):
             array = numpy.ndarray(shape=size, dtype=dtype)
             for i in range(size[0]):
                 array[i][:] = numpy.random.rand(size[1])
-            frame = AudioFrame.from_ndarray(array, format=format, layout=layout)
+            frame = AudioFrame.from_ndarray(array)
             self.assertEqual(frame.format.name, format)
             self.assertEqual(frame.layout.name, layout)
             self.assertEqual(frame.samples, 160)
@@ -140,13 +140,13 @@ class TestAudioFrameConveniences(TestCase):
     def test_ndarray_s16(self):
         layouts = [
             ("s16", "mono", "i2", (1, 160)),
-            ("s16", "stereo", "i2", (1, 320)),
+            ("s16", "stereo", "i2", (2, 160)),
             ("s16p", "mono", "i2", (1, 160)),
             ("s16p", "stereo", "i2", (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.random.randint(0, 256, size=size, dtype=dtype)
-            frame = AudioFrame.from_ndarray(array, format=format, layout=layout)
+            frame = AudioFrame.from_ndarray(array)
             self.assertEqual(frame.format.name, format)
             self.assertEqual(frame.layout.name, layout)
             self.assertEqual(frame.samples, 160)
@@ -161,13 +161,13 @@ class TestAudioFrameConveniences(TestCase):
     def test_ndarray_s32(self):
         layouts = [
             ("s32", "mono", "i4", (1, 160)),
-            ("s32", "stereo", "i4", (1, 320)),
+            ("s32", "stereo", "i4", (2, 160)),
             ("s32p", "mono", "i4", (1, 160)),
             ("s32p", "stereo", "i4", (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.random.randint(0, 256, size=size, dtype=dtype)
-            frame = AudioFrame.from_ndarray(array, format=format, layout=layout)
+            frame = AudioFrame.from_ndarray(array)
             self.assertEqual(frame.format.name, format)
             self.assertEqual(frame.layout.name, layout)
             self.assertEqual(frame.samples, 160)
@@ -176,13 +176,13 @@ class TestAudioFrameConveniences(TestCase):
     def test_ndarray_u8(self):
         layouts = [
             ("u8", "mono", "u1", (1, 160)),
-            ("u8", "stereo", "u1", (1, 320)),
+            ("u8", "stereo", "u1", (2, 160)),
             ("u8p", "mono", "u1", (1, 160)),
             ("u8p", "stereo", "u1", (2, 160)),
         ]
         for format, layout, dtype, size in layouts:
             array = numpy.random.randint(0, 256, size=size, dtype=dtype)
-            frame = AudioFrame.from_ndarray(array, format=format, layout=layout)
+            frame = AudioFrame.from_ndarray(array)
             self.assertEqual(frame.format.name, format)
             self.assertEqual(frame.layout.name, layout)
             self.assertEqual(frame.samples, 160)


### PR DESCRIPTION
Hi, congratulations for this beautiful module project!
The interface between to_ndarray and from_ndarray is not "homogeneous", I had to struggle a while to understand it. This pull request is to make the from_ndarray function easier to use.