### PR TITLE
[scratchpad] xrange() was removed in Python 3

### DIFF
--- a/scratchpad/audio.py
+++ b/scratchpad/audio.py
@@ -13,7 +13,7 @@ def print_data(frame):
         data = bytes(plane)
         print('\tPLANE %d, %d bytes' % (i, len(data)))
         data = data.encode('hex')
-        for i in xrange(0, len(data), 128):
+        for i in range(0, len(data), 128):
             print('\t\t\t%s' % data[i:i + 128])
 
 

--- a/scratchpad/decode.py
+++ b/scratchpad/decode.py
@@ -155,7 +155,7 @@ for i, packet in enumerate(container.demux(streams)):
                 data = bytes(plane)
                 print('\t\t\tPLANE %d, %d bytes' % (i, len(data)))
                 data = data.encode('hex')
-                for i in xrange(0, len(data), 128):
+                for i in range(0, len(data), 128):
                     print('\t\t\t%s' % data[i:i + 128])
 
         if args.count and frame_count >= args.count:

--- a/scratchpad/resource_use.py
+++ b/scratchpad/resource_use.py
@@ -24,7 +24,7 @@ def format_bytes(n):
 
 usage = []
 
-for round_ in xrange(args.count):
+for round_ in range(args.count):
 
     print('Round %d/%d:' % (round_ + 1, args.count))
 
@@ -55,7 +55,7 @@ for round_ in xrange(args.count):
 
 usage.append(resource.getrusage(resource.RUSAGE_SELF))
 
-for i in xrange(len(usage) - 1):
+for i in range(len(usage) - 1):
     before = usage[i]
     after = usage[i + 1]
     print('%s (%s)' % (format_bytes(after.ru_maxrss), format_bytes(after.ru_maxrss - before.ru_maxrss)))

--- a/scratchpad/seekmany.py
+++ b/scratchpad/seekmany.py
@@ -27,7 +27,7 @@ def iter_frames():
         for frame in packet.decode():
             yield frame
 
-for i in xrange(steps):
+for i in range(steps):
 
     time = real_duration * i / steps
     min_time = time - tolerance


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.0.html#views-and-iterators-instead-of-lists
> [`range()`](https://docs.python.org/3/library/stdtypes.html#range) now behaves like `xrange()` used to behave, except it works with values of arbitrary size. The latter no longer exists.