### PR TITLE
fix the doc about `time`

### DIFF
--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -68,7 +68,9 @@ cdef class Frame(object):
 
     property dts:
         """
-        The decoding timestamp in :attr:`time_base` units for this frame.
+        The decoding timestamp copied from the :class:`~av.packet.Packet` that triggered returning this frame in :attr:`time_base` units.
+
+        (if frame threading isn't used) This is also the Presentation time of this frame calculated from only :attr:`.Packet.dts` values without pts values.
 
         :type: int
         """

--- a/docs/api/time.rst
+++ b/docs/api/time.rst
@@ -38,7 +38,7 @@ Attributes that represent time on those objects will be in that object's ``time_
     >>> float(video.duration * video.time_base)
     6.72
 
-:class:`.Packet` has a :attr:`.Packet.pts` ("presentation" time stamp), and :class:`.Frame` has a :attr:`.Frame.pts` and :attr:`.Frame.dts` ("presentation" and "decode" time stamps). Both have a ``time_base`` attribute, but it defaults to the time base of the object that handles them. For packets that is streams. For frames it is streams when decoding, and codec contexts when encoding (which is strange, but it is what it is).
+:class:`.Packet` has a :attr:`.Packet.pts` and :attr:`.Packet.dts` ("presentation" and "decode" time stamps), and :class:`.Frame` has a :attr:`.Frame.pts` ("presentation" time stamp). Both have a ``time_base`` attribute, but it defaults to the time base of the object that handles them. For packets that is streams. For frames it is streams when decoding, and codec contexts when encoding (which is strange, but it is what it is).
 
 In many cases a stream has a time base of ``1 / frame_rate``, and then its frames have incrementing integers for times (0, 1, 2, etc.). Those frames take place at ``pts * time_base`` or ``0 / frame_rate``, ``1 / frame_rate``, ``2 / frame_rate``, etc..
 


### PR DESCRIPTION
Fix the doc of the `time` page and `av.frame.Frame.dts` according to https://ffmpeg.org/doxygen/5.1/structAVFrame.html#aa52951f35ec9e303d3dfeb4b3e44248a

Also, is it worth to change `av.frame.Frame.dts` to `av.frame.Frame.pkt_dts` to avoid confusion?