### PR TITLE
Added __set__ for duration property of Packet

### DIFF
--- a/av/packet.pyx
+++ b/av/packet.pyx
@@ -193,6 +193,12 @@ cdef class Packet(Buffer):
             if self.ptr.duration != lib.AV_NOPTS_VALUE:
                 return self.ptr.duration
 
+        def __set__(self, v):
+            if v is None:
+                self.ptr.duration = lib.AV_NOPTS_VALUE
+            else:
+                self.ptr.duration = v
+
     property is_keyframe:
         def __get__(self): return bool(self.ptr.flags & lib.AV_PKT_FLAG_KEY)
 


### PR DESCRIPTION
## Overview

Currently, PyAV does not provide a straightforward way to modify the duration of packets in media files. This feature request proposes to add support for modifying duration of packets in PyAV.

## Desired Behavior

PyAV should provide methods to modify duration of packets. Specifically:

A method to modify duration of packets, which can be useful for adjusting the playback speed of a video or audio file.
A method to modify packet duration can be useful for adjusting timing or frame rate in a media file.

## Example API

Here is an example API that demonstrates how PyAV could support modifying duration of packets:

```
for packet in input.demux(input_stream):
      packet.duration = int(packet.duration * packet.time_base / output_stream.time_base)
      packet.time_base = output_stream.time_base
      packet.dts = last_dts + packet.duration
      packet.pts = last_pts + packet.duration
      last_pts, last_dts = packet.pts, packet.dts
      packet.stream = output_stream
      output_container.mux(packet)
```

## Additional context

Adding support for modifying duration in PyAV would make it easier for users to adjust the timing, playback speed, and other aspects of media files using Python.