### PR TITLE
Catching AttributeError when repr(fifo) that hasn't had fifo.write(frame) called yet

### DIFF
--- a/av/audio/fifo.pyx
+++ b/av/audio/fifo.pyx
@@ -7,14 +7,21 @@ cdef class AudioFifo:
     """A simple audio sample FIFO (First In First Out) buffer."""
 
     def __repr__(self):
-        return '<av.%s %s samples of %dhz %s %s at 0x%x>' % (
-            self.__class__.__name__,
-            self.samples,
-            self.sample_rate,
-            self.layout,
-            self.format,
-            id(self),
-        )
+        try:
+            result = '<av.%s %s samples of %dhz %s %s at 0x%x>' % (
+                self.__class__.__name__,
+                self.samples,
+                self.sample_rate,
+                self.layout,
+                self.format,
+                id(self),
+            )
+        except AttributeError:
+            result = '<av.%s uninitialized, use fifo.write(frame), at 0x%x>' % (
+                self.__class__.__name__,
+                id(self),
+            )
+        return result
 
     def __dealloc__(self):
         if self.ptr:

--- a/tests/test_audiofifo.py
+++ b/tests/test_audiofifo.py
@@ -32,12 +32,26 @@ class TestAudioFifo(TestCase):
     def test_pts_simple(self):
         fifo = av.AudioFifo()
 
+        # ensure __repr__ does not crash
+        self.assertTrue(
+            str(fifo).startswith(
+                "<av.AudioFifo uninitialized, use fifo.write(frame), at 0x"
+            )
+        )
+
         iframe = av.AudioFrame(samples=1024)
         iframe.pts = 0
         iframe.sample_rate = 48000
         iframe.time_base = "1/48000"
 
         fifo.write(iframe)
+
+        # ensure __repr__ was updated
+        self.assertTrue(
+            str(fifo).startswith(
+                "<av.AudioFifo 1024 samples of 48000hz <av.AudioLayout 'stereo'> <av.AudioFormat s16> at 0x"
+            )
+        )
 
         oframe = fifo.read(512)
         self.assertTrue(oframe is not None)


### PR DESCRIPTION
This change makes debugging state errors easier by describing to the user why the state is incomplete.

Before the change:
```py
>>> AudioFifo()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "av/audio/fifo.pyx", line 15, in av.audio.fifo.AudioFifo.__repr__
  File "av/audio/fifo.pyx", line 183, in av.audio.fifo.AudioFifo.sample_rate.__get__
AttributeError: 'NoneType' object has no attribute 'sample_rate'
```

After the change:
```py
>>> AudioFifo()
<av.AudioFifo uninitialized, use fifo.write(frame), at 0x108719650>
```