### PR TITLE
Fix wheel build - pin cython<3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,7 +164,7 @@ jobs:
         conda config --set always_yes true
         conda config --add channels conda-forge
         conda create -q -n pyav \
-          cython \
+          "cython<3.0" \
           numpy \
           pillow \
           python=${{ matrix.config.python }} \
@@ -205,7 +205,7 @@ jobs:
           python-version: 3.7
       - name: Build source package
         run: |
-          pip install cython
+          pip install "cython<3.0"
           python scripts/fetch-vendor.py /tmp/vendor
           PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig python setup.py sdist
       - name: Upload source package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython"]
+requires = ["setuptools", "wheel", "cython<3.0"]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 autopep8
-Cython
+Cython<3.0
 editorconfig
 flake8
 isort


### PR DESCRIPTION
Cython `3.0` was released a few days ago which contains some breaking changes. Pin `<3.0` until issues are resolved.
https://cython.readthedocs.io/en/latest/src/changes.html#unified-release-notes

Fixes #1140