### PR TITLE
Update CI/CL, drop Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,19 @@
 name: tests
-
-on: [push, pull_request]
-
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+      - '**.txt'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+      - '**.txt'
 jobs:
-
-
   style:
-
     name: "${{ matrix.config.suite }}"
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         config:
@@ -22,14 +26,13 @@ jobs:
       PYAV_LIBRARY: ffmpeg-4.3 # doesn't matter
 
     steps:
-
       - uses: actions/checkout@v3
         name: Checkout
 
       - name: Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Environment
         run: env | sort
@@ -45,30 +48,25 @@ jobs:
           . scripts/activate.sh
           ./scripts/test ${{ matrix.config.suite }}
 
-
   nix:
-
     name: "py-${{ matrix.config.python }} lib-${{ matrix.config.ffmpeg }} ${{matrix.config.os}}"
-
     runs-on: ${{ matrix.config.os }}
-
     strategy:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest, python: 3.7, ffmpeg: "5.1", extras: true}
-          - {os: ubuntu-latest, python: 3.7, ffmpeg: "5.0"}
-          - {os: ubuntu-latest, python: 3.7, ffmpeg: "4.4"}
-          - {os: ubuntu-latest, python: 3.7, ffmpeg: "4.3"}
+          - {os: ubuntu-latest, python: 3.8, ffmpeg: "5.1", extras: true}
+          - {os: ubuntu-latest, python: 3.8, ffmpeg: "5.0"}
+          - {os: ubuntu-latest, python: 3.8, ffmpeg: "4.4"}
+          - {os: ubuntu-latest, python: 3.8, ffmpeg: "4.3"}
           - {os: ubuntu-latest, python: pypy3.9, ffmpeg: "4.4"}
-          - {os: macos-latest,  python: 3.7, ffmpeg: "4.4"}
+          - {os: macos-latest,  python: 3.8, ffmpeg: "4.4"}
 
     env:
       PYAV_PYTHON: python${{ matrix.config.python }}
       PYAV_LIBRARY: ffmpeg-${{ matrix.config.ffmpeg }}
 
     steps:
-
     - uses: actions/checkout@v3
       name: Checkout
 
@@ -138,22 +136,19 @@ jobs:
         scripts/test sdist
 
   windows:
-
     name: "py-${{ matrix.config.python }} lib-${{ matrix.config.ffmpeg }} ${{matrix.config.os}}"
-
     runs-on: ${{ matrix.config.os }}
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, python: 3.7, ffmpeg: "5.1"}
-          - {os: windows-latest, python: 3.7, ffmpeg: "5.0"}
-          - {os: windows-latest, python: 3.7, ffmpeg: "4.4"}
-          - {os: windows-latest, python: 3.7, ffmpeg: "4.3"}
+          - {os: windows-latest, python: 3.8, ffmpeg: "5.1"}
+          - {os: windows-latest, python: 3.8, ffmpeg: "5.0"}
+          - {os: windows-latest, python: 3.8, ffmpeg: "4.4"}
+          - {os: windows-latest, python: 3.8, ffmpeg: "4.3"}
 
     steps:
-
     - name: Checkout
       uses: actions/checkout@v3
 
@@ -202,7 +197,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Build source package
         run: |
           pip install cython
@@ -236,7 +231,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Set up QEMU
         if: matrix.os == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v2
@@ -259,7 +254,7 @@ jobs:
           CIBW_TEST_COMMAND: mv {project}/av {project}/av.disabled && python -m unittest discover -t {project} -s tests && mv {project}/av.disabled {project}/av
           CIBW_TEST_REQUIRES: numpy
           # skip tests when there are no binary wheels of numpy
-          CIBW_TEST_SKIP: cp37-* pp* *_i686
+          CIBW_TEST_SKIP: pp* *_i686
         run: |
           pip install cibuildwheel delvewheel
           cibuildwheel --output-dir dist
@@ -281,7 +276,7 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/av/__main__.py
+++ b/av/__main__.py
@@ -2,7 +2,6 @@ import argparse
 
 
 def main():
-
     parser = argparse.ArgumentParser()
     parser.add_argument("--codecs", action="store_true")
     parser.add_argument("--version", action="store_true")
@@ -11,7 +10,6 @@ def main():
     # ---
 
     if args.version:
-
         import av
         import av._core
 

--- a/av/datasets.py
+++ b/av/datasets.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 
 
 def iter_data_dirs(check_writable=False):
-
     try:
         yield os.environ["PYAV_TESTDATA_DIR"]
     except KeyError:
@@ -45,7 +44,6 @@ def iter_data_dirs(check_writable=False):
 
 
 def cached_download(url, name):
-
     """Download the data at a URL, and cache it under the given name.
 
     The file is stored under `pyav/test` with the given name in the directory

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ old_embed_signature = EmbedSignature._embed_signature
 
 
 def new_embed_signature(self, sig, doc):
-
     # Strip any `self` parameters from the front.
     sig = re.sub(r"\(self(,\s+)?", "(", sig)
 
@@ -192,7 +191,7 @@ setup(
     url="https://github.com/PyAV-Org/PyAV",
     packages=find_packages(exclude=["build*", "examples*", "scratchpad*", "tests*"]),
     package_data=package_data,
-    python_requires='>=3.7',
+    python_requires=">=3.8",
     zip_safe=False,
     ext_modules=ext_modules,
     test_suite="tests",
@@ -211,11 +210,11 @@ setup(
         "Operating System :: Unix",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Cython",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Multimedia :: Sound/Audio",
         "Topic :: Multimedia :: Sound/Audio :: Conversion",


### PR DESCRIPTION
Python 3.7 is EOL, let's at least use 3.8 as the minimum.