### PR TITLE
Reformat Python code with black, and enforce it in CI

### DIFF
--- a/examples/basics/parse.py
+++ b/examples/basics/parse.py
@@ -29,14 +29,12 @@ fh = open(h264_path, "rb")
 codec = av.CodecContext.create("h264", "r")
 
 while True:
-
     chunk = fh.read(1 << 16)
 
     packets = codec.parse(chunk)
     print("Parsed {} packets from {} bytes:".format(len(packets), len(chunk)))
 
     for packet in packets:
-
         print("   ", packet)
 
         frames = codec.decode(packet)

--- a/examples/basics/remux.py
+++ b/examples/basics/remux.py
@@ -11,7 +11,6 @@ in_stream = input_.streams.video[0]
 out_stream = output.add_stream(template=in_stream)
 
 for packet in input_.demux(in_stream):
-
     print(packet)
 
     # We need to skip the "flushing" packets that `demux` generates.

--- a/examples/basics/save_keyframes.py
+++ b/examples/basics/save_keyframes.py
@@ -9,7 +9,6 @@ with av.open(content) as container:
     stream.codec_context.skip_frame = "NONKEY"
 
     for frame in container.decode(stream):
-
         print(frame)
 
         # We use `frame.pts` as `frame.index` won't make must sense with the `skip_frame`.

--- a/examples/numpy/barcode.py
+++ b/examples/numpy/barcode.py
@@ -12,7 +12,6 @@ container.streams.video[0].thread_type = "AUTO"  # Go faster!
 
 columns = []
 for frame in container.decode(video=0):
-
     print(frame)
     array = frame.to_ndarray(format="rgb24")
 

--- a/examples/numpy/generate_video.py
+++ b/examples/numpy/generate_video.py
@@ -15,7 +15,6 @@ stream.height = 320
 stream.pix_fmt = "yuv420p"
 
 for frame_i in range(total_frames):
-
     img = np.empty((480, 320, 3))
     img[:, :, 0] = 0.5 + 0.5 * np.sin(2 * np.pi * (0 / 3 + frame_i / total_frames))
     img[:, :, 1] = 0.5 + 0.5 * np.sin(2 * np.pi * (1 / 3 + frame_i / total_frames))

--- a/examples/numpy/generate_video_with_pts.py
+++ b/examples/numpy/generate_video_with_pts.py
@@ -43,7 +43,6 @@ block_w2 = int(0.5 * width / total_frames * 0.75)
 block_h2 = int(0.5 * height / 4)
 
 for frame_i in range(total_frames):
-
     # move around the color wheel (hue)
     nice_color = colorsys.hsv_to_rgb(frame_i / total_frames, 1.0, 1.0)
     nice_color = (np.array(nice_color) * 255).astype(np.uint8)

--- a/scripts/test
+++ b/scripts/test
@@ -19,7 +19,7 @@ istest() {
 }
 
 if istest black; then
-    $PYAV_PYTHON -m black av examples tests
+    $PYAV_PYTHON -m black --check av examples tests
 fi
 
 if istest flake8; then

--- a/tests/test_audiofifo.py
+++ b/tests/test_audiofifo.py
@@ -5,7 +5,6 @@ from .common import TestCase, fate_suite
 
 class TestAudioFifo(TestCase):
     def test_data(self):
-
         container = av.open(fate_suite("audio-reference/chorusnoise_2ch_44kHz_s16.wav"))
         stream = container.streams.audio[0]
 
@@ -31,7 +30,6 @@ class TestAudioFifo(TestCase):
         self.assertTrue(input_[:min_len] == output[:min_len])
 
     def test_pts_simple(self):
-
         fifo = av.AudioFifo()
 
         iframe = av.AudioFrame(samples=1024)
@@ -61,7 +59,6 @@ class TestAudioFifo(TestCase):
         self.assertRaises(ValueError, fifo.write, iframe)
 
     def test_pts_complex(self):
-
         fifo = av.AudioFifo()
 
         iframe = av.AudioFrame(samples=1024)
@@ -79,7 +76,6 @@ class TestAudioFifo(TestCase):
         self.assertEqual(fifo.pts_per_sample, 2.0)
 
     def test_missing_sample_rate(self):
-
         fifo = av.AudioFifo()
 
         iframe = av.AudioFrame(samples=1024)
@@ -96,7 +92,6 @@ class TestAudioFifo(TestCase):
         self.assertEqual(oframe.time_base, iframe.time_base)
 
     def test_missing_time_base(self):
-
         fifo = av.AudioFifo()
 
         iframe = av.AudioFrame(samples=1024)

--- a/tests/test_audioresampler.py
+++ b/tests/test_audioresampler.py
@@ -69,7 +69,6 @@ class TestAudioResampler(TestCase):
         self.assertEqual(len(oframes), 0)
 
     def test_pts_assertion_same_rate(self):
-
         resampler = AudioResampler("s16", "mono")
 
         # resample one frame
@@ -115,7 +114,6 @@ class TestAudioResampler(TestCase):
         self.assertEqual(len(oframes), 0)
 
     def test_pts_assertion_new_rate(self):
-
         resampler = AudioResampler("s16", "mono", 44100)
 
         # resample one frame
@@ -144,7 +142,6 @@ class TestAudioResampler(TestCase):
         self.assertEqual(oframe.samples, 16)
 
     def test_pts_missing_time_base(self):
-
         resampler = AudioResampler("s16", "mono", 44100)
 
         # resample one frame

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -120,7 +120,6 @@ class TestCodecContext(TestCase):
         self.assertEqual(ctx.pix_fmt, "yuv420p")
 
     def test_parse(self):
-
         # This one parses into a single packet.
         self._assert_parse("mpeg4", fate_suite("h264/interlaced_crop.mp4"))
 
@@ -128,7 +127,6 @@ class TestCodecContext(TestCase):
         self._assert_parse("mpeg2video", fate_suite("mpeg2/mpeg2_field_encoding.ts"))
 
     def _assert_parse(self, codec_name, path):
-
         fh = av.open(path)
         packets = []
         for packet in fh.demux(video=0):
@@ -137,7 +135,6 @@ class TestCodecContext(TestCase):
         full_source = b"".join(bytes(p) for p in packets)
 
         for size in 1024, 8192, 65535:
-
             ctx = Codec(codec_name).create()
             packets = []
 
@@ -162,7 +159,6 @@ class TestEncoding(TestCase):
         self.image_sequence_encode("tiff")
 
     def image_sequence_encode(self, codec_name):
-
         try:
             codec = Codec(codec_name, "w")
         except UnknownCodecError:
@@ -187,7 +183,6 @@ class TestEncoding(TestCase):
         frame_count = 1
         path_list = []
         for frame in iter_frames(container, video_stream):
-
             new_frame = frame.reformat(width, height, pix_fmt)
             new_packets = ctx.encode(new_frame)
 
@@ -249,7 +244,6 @@ class TestEncoding(TestCase):
         self.video_encoding("dnxhd", options)
 
     def video_encoding(self, codec_name, options={}, codec_tag=None):
-
         try:
             codec = Codec(codec_name, "w")
         except UnknownCodecError:
@@ -280,9 +274,7 @@ class TestEncoding(TestCase):
         frame_count = 0
 
         with open(path, "wb") as f:
-
             for frame in iter_frames(container, video_stream):
-
                 new_frame = frame.reformat(width, height, pix_fmt)
 
                 # reset the picture type
@@ -326,7 +318,6 @@ class TestEncoding(TestCase):
         self.audio_encoding("mp2")
 
     def audio_encoding(self, codec_name):
-
         try:
             codec = Codec(codec_name, "w")
         except UnknownCodecError:
@@ -361,7 +352,6 @@ class TestEncoding(TestCase):
 
         with open(path, "wb") as f:
             for frame in iter_frames(container, audio_stream):
-
                 resampled_frames = resampler.resample(frame)
                 for resampled_frame in resampled_frames:
                     samples += resampled_frame.samples

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -7,7 +7,6 @@ from .common import TestCase, fate_suite
 
 class TestDecode(TestCase):
     def test_decoded_video_frame_count(self):
-
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
         video_stream = next(s for s in container.streams if s.type == "video")
 
@@ -40,7 +39,6 @@ class TestDecode(TestCase):
         self.assertEqual(frame_count, 0)
 
     def test_decode_audio_sample_count(self):
-
         container = av.open(fate_suite("audio-reference/chorusnoise_2ch_44kHz_s16.wav"))
         audio_stream = next(s for s in container.streams if s.type == "audio")
 
@@ -58,7 +56,6 @@ class TestDecode(TestCase):
         self.assertEqual(sample_count, total_samples)
 
     def test_decoded_time_base(self):
-
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
         stream = container.streams.video[0]
 
@@ -71,7 +68,6 @@ class TestDecode(TestCase):
                 return
 
     def test_decoded_motion_vectors(self):
-
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
         stream = container.streams.video[0]
         codec_context = stream.codec_context
@@ -88,7 +84,6 @@ class TestDecode(TestCase):
                     return
 
     def test_decoded_motion_vectors_no_flag(self):
-
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
         stream = container.streams.video[0]
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -23,7 +23,6 @@ class TestDeprecations(TestCase):
 
     def test_renamed_attr(self):
         class Example(object):
-
             new_value = "foo"
             old_value = deprecation.renamed_attr("new_value")
 
@@ -35,7 +34,6 @@ class TestDeprecations(TestCase):
         obj = Example()
 
         with warnings.catch_warnings(record=True) as captured:
-
             self.assertEqual(obj.old_value, "foo")
             self.assertIn(
                 "Example.old_value is deprecated", captured[0].message.args[0]

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -5,7 +5,6 @@ from .common import TestCase
 
 class TestDictionary(TestCase):
     def test_basics(self):
-
         d = Dictionary()
         d["key"] = "value"
 

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -8,9 +8,7 @@ import av.datasets
 
 
 def fix_doctests(suite):
-
     for case in suite._tests:
-
         # Add some more flags.
         case._dt_optionflags = (
             (case._dt_optionflags or 0)
@@ -25,14 +23,12 @@ def fix_doctests(suite):
         )
 
         for example in case._dt_test.examples:
-
             # Remove b prefix from strings.
             if example.want.startswith("b'"):
                 example.want = example.want[1:]
 
 
 def register_doctests(mod):
-
     if isinstance(mod, str):
         mod = __import__(mod, fromlist=[""])
 

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -16,7 +16,6 @@ DURATION = 48
 
 
 def write_rgb_rotate(output):
-
     if not Image:
         raise SkipTest()
 
@@ -29,7 +28,6 @@ def write_rgb_rotate(output):
     stream.pix_fmt = "yuv420p"
 
     for frame_i in range(DURATION):
-
         frame = VideoFrame(WIDTH, HEIGHT, "rgb24")
         image = Image.new(
             "RGB",
@@ -64,7 +62,6 @@ def write_rgb_rotate(output):
 
 
 def assert_rgb_rotate(self, input_, is_dash=False):
-
     # Now inspect it a little.
     self.assertEqual(len(input_.streams), 1)
     if is_dash:

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -22,7 +22,6 @@ class TestEnums(TestCase):
         )
 
     def test_basics(self):
-
         cls = self.define_foobar()
 
         self.assertIsInstance(cls, EnumType)
@@ -36,7 +35,6 @@ class TestEnums(TestCase):
         self.assertNotIsInstance(foo, PickleableFooBar)
 
     def test_access(self):
-
         cls = self.define_foobar()
         foo1 = cls.FOO
         foo2 = cls["FOO"]
@@ -58,7 +56,6 @@ class TestEnums(TestCase):
         self.assertIs(cls.get("not a foo"), None)
 
     def test_casting(self):
-
         cls = self.define_foobar()
         foo = cls.FOO
 
@@ -77,7 +74,6 @@ class TestEnums(TestCase):
         self.assertEqual(list(cls), [cls.FOO, cls.BAR])
 
     def test_equality(self):
-
         cls = self.define_foobar()
         foo = cls.FOO
         bar = cls.BAR
@@ -94,7 +90,6 @@ class TestEnums(TestCase):
         self.assertRaises(TypeError, lambda: foo == ())
 
     def test_as_key(self):
-
         cls = self.define_foobar()
         foo = cls.FOO
 
@@ -104,7 +99,6 @@ class TestEnums(TestCase):
         self.assertIs(d.get(1), None)
 
     def test_pickleable(self):
-
         cls = PickleableFooBar
         foo = cls.FOO
 
@@ -115,7 +109,6 @@ class TestEnums(TestCase):
         self.assertIs(foo, foo2)
 
     def test_create_unknown(self):
-
         cls = self.define_foobar()
         baz = cls.get(3, create=True)
 
@@ -123,7 +116,6 @@ class TestEnums(TestCase):
         self.assertEqual(baz.value, 3)
 
     def test_multiple_names(self):
-
         cls = define_enum(
             "FFooBBar",
             __name__,
@@ -147,7 +139,6 @@ class TestEnums(TestCase):
         self.assertRaises(ValueError, lambda: cls.F == "x")
 
     def test_flag_basics(self):
-
         cls = define_enum(
             "FoobarAllFlags",
             __name__,
@@ -178,7 +169,6 @@ class TestEnums(TestCase):
         self.assertIs(x, cls.FOO)
 
     def test_multi_flags_basics(self):
-
         cls = self.define_foobar(is_flags=True)
 
         foo = cls.FOO
@@ -202,7 +192,6 @@ class TestEnums(TestCase):
         self.assertEqual(list(cls), [foo, bar])
 
     def test_multi_flags_create_missing(self):
-
         cls = self.define_foobar(is_flags=True)
 
         foobar = cls[3]
@@ -212,7 +201,6 @@ class TestEnums(TestCase):
         self.assertRaises(KeyError, lambda: cls[7])  # FOO and BAR and missing flag.
 
     def test_properties(self):
-
         Flags = self.define_foobar(is_flags=True)
         foobar = Flags.FOO | Flags.BAR
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,7 +8,6 @@ from .common import TestCase, is_windows
 
 class TestErrorBasics(TestCase):
     def test_stringify(self):
-
         for cls in (av.ValueError, av.FileNotFoundError, av.DecoderNotFoundError):
             e = cls(1, "foo")
             self.assertEqual(str(e), "[Errno 1] foo")
@@ -34,7 +33,6 @@ class TestErrorBasics(TestCase):
             )
 
     def test_bases(self):
-
         self.assertTrue(issubclass(av.ValueError, ValueError))
         self.assertTrue(issubclass(av.ValueError, av.FFmpegError))
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -50,7 +50,6 @@ def pull_until_blocked(graph):
 
 class TestFilters(TestCase):
     def test_filter_descriptor(self):
-
         f = Filter("testsrc")
         self.assertEqual(f.name, "testsrc")
         self.assertEqual(f.description, "Generate test pattern.")
@@ -62,7 +61,6 @@ class TestFilters(TestCase):
         self.assertEqual(f.outputs[0].type, "video")
 
     def test_dynamic_filter_descriptor(self):
-
         f = Filter("split")
         self.assertFalse(f.dynamic_inputs)
         self.assertEqual(len(f.inputs), 1)
@@ -70,7 +68,6 @@ class TestFilters(TestCase):
         self.assertEqual(len(f.outputs), 0)
 
     def test_generator_graph(self):
-
         graph = Graph()
         src = graph.add("testsrc")
         lutrgb = graph.add(
@@ -93,7 +90,6 @@ class TestFilters(TestCase):
             frame.to_image().save(self.sandboxed("mandelbrot2.png"))
 
     def test_auto_find_sink(self):
-
         graph = Graph()
         src = graph.add("testsrc")
         src.link_to(graph.add("buffersink"))
@@ -105,7 +101,6 @@ class TestFilters(TestCase):
             frame.to_image().save(self.sandboxed("mandelbrot3.png"))
 
     def test_delegate_sink(self):
-
         graph = Graph()
         src = graph.add("testsrc")
         src.link_to(graph.add("buffersink"))
@@ -117,7 +112,6 @@ class TestFilters(TestCase):
             frame.to_image().save(self.sandboxed("mandelbrot4.png"))
 
     def test_haldclut_graph(self):
-
         raise SkipTest()
 
         graph = Graph()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -22,7 +22,6 @@ class TestLogging(TestCase):
         )
 
     def test_threaded_captures(self):
-
         with av.logging.Capture(local=True) as logs:
             do_log("main")
             thread = threading.Thread(target=do_log, args=("thread",))
@@ -32,7 +31,6 @@ class TestLogging(TestCase):
         self.assertIn((av.logging.INFO, "test", "main"), logs)
 
     def test_global_captures(self):
-
         with av.logging.Capture(local=False) as logs:
             do_log("main")
             thread = threading.Thread(target=do_log, args=("thread",))
@@ -43,7 +41,6 @@ class TestLogging(TestCase):
         self.assertIn((av.logging.INFO, "test", "thread"), logs)
 
     def test_repeats(self):
-
         with av.logging.Capture() as logs:
             do_log("foo")
             do_log("foo")
@@ -66,7 +63,6 @@ class TestLogging(TestCase):
         )
 
     def test_error(self):
-
         log = (av.logging.ERROR, "test", "This is a test.")
         av.logging.log(*log)
         try:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -6,7 +6,6 @@ from .common import TestCase
 
 class TestOptions(TestCase):
     def test_mov_options(self):
-
         mov = ContainerFormat("mov")
         options = mov.descriptor.options
         by_name = {opt.name: opt for opt in options}

--- a/tests/test_python_io.py
+++ b/tests/test_python_io.py
@@ -171,7 +171,6 @@ class TestPythonIO(TestCase):
 
     @run_in_sandbox
     def test_writing_to_custom_io_dash(self):
-
         # Custom I/O that opens file and logs calls
         wrapped_custom_io = CustomIOLogger()
 
@@ -207,7 +206,6 @@ class TestPythonIO(TestCase):
             assert_rgb_rotate(self, container, is_dash=True)
 
     def test_writing_to_custom_io_image2(self):
-
         if not Image:
             raise SkipTest()
 

--- a/tests/test_seek.py
+++ b/tests/test_seek.py
@@ -88,7 +88,6 @@ class TestSeek(TestCase):
         self.assertTrue(seek_packet_count < middle_packet_count)
 
     def test_decode_half(self):
-
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
 
         video_stream = next(s for s in container.streams if s.type == "video")
@@ -127,7 +126,6 @@ class TestSeek(TestCase):
         self.assertEqual(frame_count, total_frame_count - target_frame)
 
     def test_stream_seek(self):
-
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
 
         video_stream = next(s for s in container.streams if s.type == "video")

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -5,9 +5,7 @@ from .common import TestCase, fate_suite
 
 class TestStreams(TestCase):
     def test_stream_tuples(self):
-
         for fate_name in ("h264/interlaced_crop.mp4",):
-
             container = av.open(fate_suite(fate_name))
 
             video_streams = tuple([s for s in container.streams if s.type == "video"])
@@ -17,7 +15,6 @@ class TestStreams(TestCase):
             self.assertEqual(audio_streams, container.streams.audio)
 
     def test_selection(self):
-
         container = av.open(fate_suite("h264/interlaced_crop.mp4"))
         video = container.streams.video[0]
         # audio_stream = container.streams.audio[0]

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -6,7 +6,6 @@ from .common import TestCase, fate_suite
 
 class TestSubtitle(TestCase):
     def test_movtext(self):
-
         path = fate_suite("sub/MovText_capability_tester.mp4")
 
         subs = []
@@ -27,7 +26,6 @@ class TestSubtitle(TestCase):
         self.assertEqual(sub.ass, "0,0,Default,,0,0,0,,- Test 1.\\N- Test 2.")
 
     def test_vobsub(self):
-
         path = fate_suite("sub/vobsub.sub")
 
         subs = []

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -492,7 +492,6 @@ class TestVideoFrameReformat(TestCase):
         self.assertIs(frame1, frame2)
 
     def test_reformat_colourspace(self):
-
         # This is allowed.
         frame = VideoFrame(640, 480, "rgb24")
         frame.reformat(src_colorspace=None, dst_colorspace="smpte240")


### PR DESCRIPTION
It turns out we weren't actually enforcing black, because we missed the `--check` flag!