### PR TITLE
Update our binaries for FFmpeg 5.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,7 +162,7 @@ jobs:
           python=${{ matrix.config.python }} \
           setuptools
         if [[ "${{ matrix.config.ffmpeg }}" == "5.1" ]]; then
-          curl -L -o ffmpeg.tar.gz https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.1.2-1/ffmpeg-win_amd64.tar.gz
+          curl -L -o ffmpeg.tar.gz https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.1.3-1/ffmpeg-win_amd64.tar.gz
         elif [[ "${{ matrix.config.ffmpeg }}" == "5.0" ]]; then
           curl -L -o ffmpeg.tar.gz https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.0.1-1/ffmpeg-win_amd64.tar.gz
         else

--- a/docs/overview/installation.rst
+++ b/docs/overview/installation.rst
@@ -11,7 +11,7 @@ Since release 8.0.0 binary wheels are provided on PyPI for Linux, Mac and Window
     pip install av
 
 
-Currently FFmpeg 5.1.2 is used with the following features enabled for all platforms:
+Currently FFmpeg 5.1.3 is used with the following features enabled for all platforms:
 
 - fontconfig
 - gmp
@@ -26,7 +26,6 @@ Currently FFmpeg 5.1.2 is used with the following features enabled for all platf
 - libopenjpeg
 - libopus
 - libspeex
-- libtheora
 - libtwolame
 - libvorbis
 - libvpx

--- a/scripts/fetch-vendor.json
+++ b/scripts/fetch-vendor.json
@@ -1,3 +1,3 @@
 {
-    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.1.2-1/ffmpeg-{platform}.tar.gz"]
+    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.1.3-1/ffmpeg-{platform}.tar.gz"]
 }


### PR DESCRIPTION
In addition to updating FFmpeg to version 5.1.3, this updates libvpx to fix the CVE-2023-5217 buffer overflow vulnerability.