### PR TITLE
removed unsupported VideoCodecContext.gop_size.__get__ method

### DIFF
--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -126,9 +126,6 @@ cdef class VideoCodecContext(CodecContext):
             self.framerate = value
 
     property gop_size:
-        def __get__(self):
-            return self.ptr.gop_size
-
         def __set__(self, int value):
             self.ptr.gop_size = value
 


### PR DESCRIPTION
Fix [this issue](https://github.com/PyAV-Org/PyAV/issues/1254).

I believe ffmpeg does not support getting the GOP size, therefore the returned value is incorrect.

This is my first pull request so let me know if I'm doing it wrong. 