### PR TITLE
Test for VideoCodecContext.gop_size setter

### DIFF
--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -130,7 +130,11 @@ cdef class VideoCodecContext(CodecContext):
             self.framerate = value
 
     property gop_size:
-        """This only makes sense for encoders."""
+        """
+        Sets the number of frames between keyframes. Used only for encoding.
+        
+        :type: int
+        """
         def __get__(self):
             if self.is_decoder:
                 warnings.warn(


### PR DESCRIPTION
I tried to write a test for `VideoCodecContext.gop_size.__set__()` and I was surprised to find some inconsistencies. 

When using libx264, one of the GOPs will be 1 frame larger than what it's supposed to be, but only when using one of these GOP sizes: 3, 4, 6, 8, 12, 16, 24, 48. I have no idea why this happens, so for the test I chose a gop_size that didn't cause this issue.

Also, dvvideo and dnxhd will always make every frame a keyframe. Currently when this is detected, the test will skip that iteration. I'm open to other suggestions.
