### PR TITLE
Prevent repeating frame indices

### DIFF
--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -43,6 +43,7 @@ cdef class CodecContext:
     cdef _prepare_and_time_rebase_frames_for_encode(self, Frame frame)
     cdef _prepare_frames_for_encode(self, Frame frame)
     cdef _setup_encoded_packet(self, Packet)
+    cdef _correct_frame_indices(self, frame_list)
     cdef _setup_decoded_frame(self, Frame, Packet)
 
     # Implemented by base for the generic send/recv API.

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -124,3 +124,22 @@ class TestDecode(TestCase):
                     getattr(container, attr)
                 except AssertionError:
                     pass
+
+    def test_decode_frame_indices(self):
+        for thread_type in ("NONE", "AUTO"):
+            for thread_count in range(4):
+                for skip_type in ("NONE", "NONKEY"):
+                    frame_list = []
+                    compare_list = []
+                    frame_count = 0
+                    with av.open(fate_suite("h264/interlaced_crop.mp4")) as container:
+                        stream = container.streams.video[0]
+                        stream.thread_type = thread_type
+                        stream.thread_count = thread_count
+                        stream.codec_context.skip_frame = skip_type
+                        for packet in container.demux(stream):
+                            for frame in packet.decode():
+                                frame_list.append(frame.index)
+                                compare_list.append(frame_count)
+                                frame_count += 1
+                    self.assertEqual(frame_list, compare_list)


### PR DESCRIPTION
Fix for Issue #1158.

#### Problem
`stream.thread_type.FRAME` threading causes an incorrect series of repeating frame indices at the end of most videos. This is because a list of frames is returned by [`CodecContext._send_packet_and_recv`](https://github.com/PyAV-Org/PyAV/blob/1962443425d9f63c80d220546ac5f3dfb0799f6f/av/codec/context.pyx#L405) . `frame.index` corresponds to the most recent frame received from the decoder. Therefore all frames in the list are assigned the same index as the final frame in the list.

#### Solution
I solved this issue by detecting whenever multiple frames are returned and then correcting the `frame.index` based on the frame's position in the list.

#### Other changes
`AVCodecContext::frame_number` [is deprecated](https://ffmpeg.org//doxygen/trunk/structAVCodecContext.html#a1606ae31b14af5a2940b94c99264c0fc). I switched to `AVCodecContext::frame_num`.
EDIT: The deprecation was issued in ffmpeg 6.0, so I reverted back to using `AVCodecContext::frame_number`.

#### Testing
The test iterations may be overkill, but it only increased the test run time from 6 seconds to 6.5 seconds on my machine.

#### Future considerations
It is important to note that `frame.index` is affected by `CodecContext.skip_frame`. Skipped frames will not increment the frame index. I don't know if this is intended or desired behavior. Perhaps we should consider two different frame properties.
1: A property for the number of frames returned by the decoder (this is the current behavior). 
2: A property for the frame index relative to the total number of frames in the video. I assume this can be determined by a timestamp?