### PR TITLE
Stop using `wheel` as an unconditional build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython"]
+requires = ["setuptools", "cython"]
 
 [tool.isort]
 default_section = "THIRDPARTY"


### PR DESCRIPTION
It used to be an incorrect recommendation in some of the upstream docs. `setuptools` auto-injects it when building wheels and it's unnecessary when building sdist.