### PR TITLE
Add support for ffmpeg's AVCodecContext::delay

### DIFF
--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -640,3 +640,13 @@ cdef class CodecContext:
 
         def __set__(self, value):
             self.ptr.skip_frame = SkipType[value].value
+
+    property delay:
+        """Codec delay.
+
+        Wraps :ffmpeg:`AVCodecContext.delay`.
+
+        """
+
+        def __get__(self):
+            return self.ptr.delay

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -30,6 +30,7 @@ class TestCodecs(TestCase):
         self.assertIn(c.id, (12, 13))
         self.assertTrue(c.is_decoder)
         self.assertFalse(c.is_encoder)
+        self.assertTrue(c.delay)
 
         # audio
         self.assertIsNone(c.audio_formats)
@@ -51,6 +52,7 @@ class TestCodecs(TestCase):
         self.assertIn(c.id, (12, 13))
         self.assertTrue(c.is_encoder)
         self.assertFalse(c.is_decoder)
+        self.assertTrue(c.delay)
 
         # audio
         self.assertIsNone(c.audio_formats)
@@ -72,6 +74,7 @@ class TestCodecs(TestCase):
         self.assertEqual(c.type, "audio")
         self.assertTrue(c.is_decoder)
         self.assertFalse(c.is_encoder)
+        self.assertTrue(c.delay)
 
         # audio
         self.assertIsNone(c.audio_formats)
@@ -89,6 +92,7 @@ class TestCodecs(TestCase):
         self.assertEqual(c.type, "audio")
         self.assertTrue(c.is_encoder)
         self.assertFalse(c.is_decoder)
+        self.assertTrue(c.delay)
 
         # audio
         formats = c.audio_formats

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -44,6 +44,12 @@ class TestCodecContext(TestCase):
         ctx = Codec("png", "w").create()
         self.assertEqual(ctx.skip_frame.name, "DEFAULT")
 
+    def test_codec_delay(self):
+        with av.open(fate_suite("mkv/codec_delay_opus.mkv")) as container:
+            self.assertEqual(container.streams.audio[0].codec_context.delay, 312)
+        with av.open(fate_suite("h264/interlaced_crop.mp4")) as container:
+            self.assertEqual(container.streams.video[0].codec_context.delay, 0)
+
     def test_codec_tag(self):
         ctx = Codec("mpeg4", "w").create()
         self.assertEqual(ctx.codec_tag, "\x00\x00\x00\x00")


### PR DESCRIPTION
This :type: int `delay` variable is currently inaccessible:
https://github.com/PyAV-Org/PyAV/blob/8e32fe7ed7b83eff27682b4e026e7320cb8dfe1e/include/libavcodec/avcodec.pxd#L192

I assume this is supposed to be a reference to ffmpeg's [AVCodecContext::delay](https://ffmpeg.org/doxygen/6.0/structAVCodecContext.html#a948993adfdfcd64b81dad1151fe50f33).

This PR creates a property `codec_context.delay` which references ffmpeg's `AVCodecContext::delay`.

There is a separate, but similarly named, PyAV property `codec.delay` which is a reference to ffmpeg's [AV_CODEC_CAP_DELAY](https://ffmpeg.org/doxygen/6.0/group__lavc__core.html#ga3f55f5bcfbb12e06c7cb1195028855e6).
We might want to rename one of these properties to prevent confusion.


#### Tests
Since the ffmpeg docs for `AVCodecContext::delay` state "Set by libavcodec.", I was unsure how to test this property. I ended up finding a file in the FATE suite with a detected delay value. I verified the value (312 for this example) using ffprobe.

If this is an acceptable testing strategy, then I could write up more tests to help merge some of the other PRs.