### PR TITLE
Check None packet when setting time_base after decode

### DIFF
--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -527,7 +527,8 @@ cdef class CodecContext:
         # is carrying around.
         # TODO: Somehow get this from the stream so we can not pass the
         # packet here (because flushing packets are bogus).
-        frame._time_base = packet._time_base
+        if packet is not None:
+            frame._time_base = packet._time_base
 
         frame.index = self.ptr.frame_number - 1
 


### PR DESCRIPTION
Fixes https://github.com/PyAV-Org/PyAV/issues/1280