### PR TITLE
Deprecate frame.index

### DIFF
--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -4,6 +4,10 @@ from av.audio.plane cimport AudioPlane
 from av.error cimport err_check
 from av.utils cimport check_ndarray, check_ndarray_shape
 
+import warnings
+
+from av.deprecation import AVDeprecationWarning
+
 
 cdef object _cinit_bypass_sentinel
 
@@ -193,3 +197,12 @@ cdef class AudioFrame(Frame):
 
         # convert and return data
         return np.vstack([np.frombuffer(x, dtype=dtype, count=count) for x in self.planes])
+
+    def __getattribute__(self, attribute):
+        "This method should be deleted when `frame.index` is removed."
+        if attribute == 'index':
+            warnings.warn(
+                "Using `frame.index` is deprecated.",
+                AVDeprecationWarning
+            )
+        return Frame.__getattribute__(self, attribute)

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -8,6 +8,10 @@ from av.utils cimport check_ndarray, check_ndarray_shape
 from av.video.format cimport get_pix_fmt, get_video_format
 from av.video.plane cimport VideoPlane, YUVPlanes
 
+import warnings
+
+from av.deprecation import AVDeprecationWarning
+
 
 cdef object _cinit_bypass_sentinel
 
@@ -580,3 +584,12 @@ cdef class VideoFrame(Frame):
         copy_array_to_plane(array, frame.planes[0], 1 if array.ndim == 2 else array.shape[2])
 
         return frame
+
+    def __getattribute__(self, attribute):
+        "This method should be deleted when `frame.index` is removed."
+        if attribute == 'index':
+            warnings.warn(
+                "Using `frame.index` is deprecated.",
+                AVDeprecationWarning
+            )
+        return Frame.__getattribute__(self, attribute)

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -90,6 +90,17 @@ class TestCodecContext(TestCase):
                 "Using VideoCodecContext.gop_size for decoders is deprecated.",
             )
 
+    def test_frame_index(self):
+        container = av.open(fate_suite("h264/interlaced_crop.mp4"))
+        stream = container.streams[0]
+        for frame in container.decode(stream):
+            with warnings.catch_warnings(record=True) as captured:
+                self.assertIsInstance(frame.index, int)
+                self.assertEqual(
+                    captured[0].message.args[0],
+                    "Using `frame.index` is deprecated.",
+                )
+
     def test_decoder_timebase(self):
         ctx = av.codec.Codec("h264", "r").create()
 
@@ -319,7 +330,7 @@ class TestEncoding(TestCase):
             self.assertEqual(frame.height, height)
             self.assertEqual(frame.format.name, pix_fmt)
             if frame.key_frame:
-                keyframe_indices.append(frame.index)
+                keyframe_indices.append(decoded_frame_count)
 
         self.assertEqual(frame_count, decoded_frame_count)
 


### PR DESCRIPTION
Created a deprecation warning and a test to catch it. Also, replaced `frame.index` from a previous test I wrote.