### PR TITLE
Convert Cython extension class properties to decorator syntax part 1 of 4

### DIFF
--- a/av/descriptor.pyx
+++ b/av/descriptor.pyx
@@ -18,42 +18,42 @@ cdef class Descriptor:
         if sentinel is not _cinit_sentinel:
             raise RuntimeError("Cannot construct av.Descriptor")
 
-    property name:
-        def __get__(self):
-            return self.ptr.class_name if self.ptr.class_name else None
+    @property
+    def name(self):
+        return self.ptr.class_name if self.ptr.class_name else None
 
-    property options:
-        def __get__(self):
-            cdef const lib.AVOption *ptr = self.ptr.option
-            cdef const lib.AVOption *choice_ptr
-            cdef Option option
-            cdef OptionChoice option_choice
-            cdef bint choice_is_default
-            if self._options is None:
-                options = []
-                ptr = self.ptr.option
-                while ptr != NULL and ptr.name != NULL:
-                    if ptr.type == lib.AV_OPT_TYPE_CONST:
-                        ptr += 1
-                        continue
-                    choices = []
-                    if ptr.unit != NULL:  # option has choices (matching const options)
-                        choice_ptr = self.ptr.option
-                        while choice_ptr != NULL and choice_ptr.name != NULL:
-                            if choice_ptr.type != lib.AV_OPT_TYPE_CONST or choice_ptr.unit != ptr.unit:
-                                choice_ptr += 1
-                                continue
-                            choice_is_default = (choice_ptr.default_val.i64 == ptr.default_val.i64 or
-                                                 ptr.type == lib.AV_OPT_TYPE_FLAGS and
-                                                 choice_ptr.default_val.i64 & ptr.default_val.i64)
-                            option_choice = wrap_option_choice(choice_ptr, choice_is_default)
-                            choices.append(option_choice)
-                            choice_ptr += 1
-                    option = wrap_option(tuple(choices), ptr)
-                    options.append(option)
+    @property
+    def options(self):
+        cdef const lib.AVOption *ptr = self.ptr.option
+        cdef const lib.AVOption *choice_ptr
+        cdef Option option
+        cdef OptionChoice option_choice
+        cdef bint choice_is_default
+        if self._options is None:
+            options = []
+            ptr = self.ptr.option
+            while ptr != NULL and ptr.name != NULL:
+                if ptr.type == lib.AV_OPT_TYPE_CONST:
                     ptr += 1
-                self._options = tuple(options)
-            return self._options
+                    continue
+                choices = []
+                if ptr.unit != NULL:  # option has choices (matching const options)
+                    choice_ptr = self.ptr.option
+                    while choice_ptr != NULL and choice_ptr.name != NULL:
+                        if choice_ptr.type != lib.AV_OPT_TYPE_CONST or choice_ptr.unit != ptr.unit:
+                            choice_ptr += 1
+                            continue
+                        choice_is_default = (choice_ptr.default_val.i64 == ptr.default_val.i64 or
+                                             ptr.type == lib.AV_OPT_TYPE_FLAGS and
+                                             choice_ptr.default_val.i64 & ptr.default_val.i64)
+                        option_choice = wrap_option_choice(choice_ptr, choice_is_default)
+                        choices.append(option_choice)
+                        choice_ptr += 1
+                option = wrap_option(tuple(choices), ptr)
+                options.append(option)
+                ptr += 1
+            self._options = tuple(options)
+        return self._options
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.name} at 0x{id(self):x}>"

--- a/av/format.pyx
+++ b/av/format.pyx
@@ -81,59 +81,59 @@ cdef class ContainerFormat:
     def __repr__(self):
         return f"<av.{self.__class__.__name__} {self.name!r}>"
 
-    property descriptor:
-        def __get__(self):
-            if self.iptr:
-                return wrap_avclass(self.iptr.priv_class)
-            else:
-                return wrap_avclass(self.optr.priv_class)
+    @property
+    def descriptor(self):
+        if self.iptr:
+            return wrap_avclass(self.iptr.priv_class)
+        else:
+            return wrap_avclass(self.optr.priv_class)
 
-    property options:
-        def __get__(self):
-            return self.descriptor.options
+    @property
+    def options(self):
+        return self.descriptor.options
 
-    property input:
+    @property
+    def input(self):
         """An input-only view of this format."""
-        def __get__(self):
-            if self.iptr == NULL:
-                return None
-            elif self.optr == NULL:
-                return self
-            else:
-                return build_container_format(self.iptr, NULL)
+        if self.iptr == NULL:
+            return None
+        elif self.optr == NULL:
+            return self
+        else:
+            return build_container_format(self.iptr, NULL)
 
-    property output:
+    @property
+    def output(self):
         """An output-only view of this format."""
-        def __get__(self):
-            if self.optr == NULL:
-                return None
-            elif self.iptr == NULL:
-                return self
-            else:
-                return build_container_format(NULL, self.optr)
+        if self.optr == NULL:
+            return None
+        elif self.iptr == NULL:
+            return self
+        else:
+            return build_container_format(NULL, self.optr)
 
-    property is_input:
-        def __get__(self):
-            return self.iptr != NULL
+    @property
+    def is_input(self):
+        return self.iptr != NULL
 
-    property is_output:
-        def __get__(self):
-            return self.optr != NULL
+    @property
+    def is_output(self):
+        return self.optr != NULL
 
-    property long_name:
-        def __get__(self):
-            # We prefer the output names since the inputs may represent
-            # multiple formats.
-            return self.optr.long_name if self.optr else self.iptr.long_name
+    @property
+    def long_name(self):
+        # We prefer the output names since the inputs may represent
+        # multiple formats.
+        return self.optr.long_name if self.optr else self.iptr.long_name
 
-    property extensions:
-        def __get__(self):
-            cdef set exts = set()
-            if self.iptr and self.iptr.extensions:
-                exts.update(self.iptr.extensions.split(","))
-            if self.optr and self.optr.extensions:
-                exts.update(self.optr.extensions.split(","))
-            return exts
+    @property
+    def extensions(self):
+        cdef set exts = set()
+        if self.iptr and self.iptr.extensions:
+            exts.update(self.iptr.extensions.split(","))
+        if self.optr and self.optr.extensions:
+            exts.update(self.optr.extensions.split(","))
+        return exts
 
     @Flags.property
     def flags(self):

--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -55,7 +55,8 @@ cdef class Frame:
 
         self._time_base = dst
 
-    property dts:
+    @property
+    def dts(self):
         """
         The decoding timestamp copied from the :class:`~av.packet.Packet` that triggered returning this frame in :attr:`time_base` units.
 
@@ -63,18 +64,19 @@ cdef class Frame:
 
         :type: int
         """
-        def __get__(self):
-            if self.ptr.pkt_dts == lib.AV_NOPTS_VALUE:
-                return None
-            return self.ptr.pkt_dts
+        if self.ptr.pkt_dts == lib.AV_NOPTS_VALUE:
+            return None
+        return self.ptr.pkt_dts
 
-        def __set__(self, value):
-            if value is None:
-                self.ptr.pkt_dts = lib.AV_NOPTS_VALUE
-            else:
-                self.ptr.pkt_dts = value
+    @dts.setter
+    def dts(self, value):
+        if value is None:
+            self.ptr.pkt_dts = lib.AV_NOPTS_VALUE
+        else:
+            self.ptr.pkt_dts = value
 
-    property pts:
+    @property
+    def pts(self):
         """
         The presentation timestamp in :attr:`time_base` units for this frame.
 
@@ -82,18 +84,19 @@ cdef class Frame:
 
         :type: int
         """
-        def __get__(self):
-            if self.ptr.pts == lib.AV_NOPTS_VALUE:
-                return None
-            return self.ptr.pts
+        if self.ptr.pts == lib.AV_NOPTS_VALUE:
+            return None
+        return self.ptr.pts
 
-        def __set__(self, value):
-            if value is None:
-                self.ptr.pts = lib.AV_NOPTS_VALUE
-            else:
-                self.ptr.pts = value
+    @pts.setter
+    def pts(self, value):
+        if value is None:
+            self.ptr.pts = lib.AV_NOPTS_VALUE
+        else:
+            self.ptr.pts = value
 
-    property time:
+    @property
+    def time(self):
         """
         The presentation time in seconds for this frame.
 
@@ -101,33 +104,33 @@ cdef class Frame:
 
         :type: float
         """
-        def __get__(self):
-            if self.ptr.pts == lib.AV_NOPTS_VALUE:
-                return None
-            else:
-                return float(self.ptr.pts) * self._time_base.num / self._time_base.den
+        if self.ptr.pts == lib.AV_NOPTS_VALUE:
+            return None
+        else:
+            return float(self.ptr.pts) * self._time_base.num / self._time_base.den
 
-    property time_base:
+    @property
+    def time_base(self):
         """
         The unit of time (in fractional seconds) in which timestamps are expressed.
 
         :type: fractions.Fraction
         """
-        def __get__(self):
-            if self._time_base.num:
-                return avrational_to_fraction(&self._time_base)
+        if self._time_base.num:
+            return avrational_to_fraction(&self._time_base)
 
-        def __set__(self, value):
-            to_avrational(value, &self._time_base)
+    @time_base.setter
+    def time_base(self, value):
+        to_avrational(value, &self._time_base)
 
-    property is_corrupt:
+    @property
+    def is_corrupt(self):
         """
         Is this frame corrupt?
 
         :type: bool
         """
-        def __get__(self):
-            return self.ptr.decode_error_flags != 0 or bool(self.ptr.flags & lib.AV_FRAME_FLAG_CORRUPT)
+        return self.ptr.decode_error_flags != 0 or bool(self.ptr.flags & lib.AV_FRAME_FLAG_CORRUPT)
 
     @property
     def side_data(self):

--- a/av/option.pyx
+++ b/av/option.pyx
@@ -64,82 +64,82 @@ cdef class BaseOption:
         if sentinel is not _cinit_sentinel:
             raise RuntimeError(f"Cannot construct av.{self.__class__.__name__}")
 
-    property name:
-        def __get__(self):
-            return self.ptr.name
+    @property
+    def name(self):
+        return self.ptr.name
 
-    property help:
-        def __get__(self):
-            return self.ptr.help if self.ptr.help != NULL else ""
+    @property
+    def help(self):
+        return self.ptr.help if self.ptr.help != NULL else ""
 
-    property flags:
-        def __get__(self):
-            return self.ptr.flags
+    @property
+    def flags(self):
+        return self.ptr.flags
 
     # Option flags
-    property is_encoding_param:
-        def __get__(self):
-            return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_ENCODING_PARAM)
-    property is_decoding_param:
-        def __get__(self):
-            return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_DECODING_PARAM)
-    property is_audio_param:
-        def __get__(self):
-            return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_AUDIO_PARAM)
-    property is_video_param:
-        def __get__(self):
-            return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_VIDEO_PARAM)
-    property is_subtitle_param:
-        def __get__(self):
-            return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_SUBTITLE_PARAM)
-    property is_export:
-        def __get__(self):
-            return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_EXPORT)
-    property is_readonly:
-        def __get__(self):
-            return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_READONLY)
-    property is_filtering_param:
-        def __get__(self):
-            return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_FILTERING_PARAM)
+    @property
+    def is_encoding_param(self):
+        return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_ENCODING_PARAM)
+    @property
+    def is_decoding_param(self):
+        return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_DECODING_PARAM)
+    @property
+    def is_audio_param(self):
+        return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_AUDIO_PARAM)
+    @property
+    def is_video_param(self):
+        return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_VIDEO_PARAM)
+    @property
+    def is_subtitle_param(self):
+        return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_SUBTITLE_PARAM)
+    @property
+    def is_export(self):
+        return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_EXPORT)
+    @property
+    def is_readonly(self):
+        return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_READONLY)
+    @property
+    def is_filtering_param(self):
+        return flag_in_bitfield(self.ptr.flags, lib.AV_OPT_FLAG_FILTERING_PARAM)
 
 
 cdef class Option(BaseOption):
-    property type:
-        def __get__(self):
-            return OptionType._get(self.ptr.type, create=True)
+    @property
+    def type(self):
+        return OptionType._get(self.ptr.type, create=True)
 
-    property offset:
+    @property
+    def offset(self):
         """
         This can be used to find aliases of an option.
         Options in a particular descriptor with the same offset are aliases.
         """
-        def __get__(self):
-            return self.ptr.offset
+        return self.ptr.offset
 
-    property default:
-        def __get__(self):
-            if self.ptr.type in _INT_TYPES:
-                return self.ptr.default_val.i64
-            if self.ptr.type in (lib.AV_OPT_TYPE_DOUBLE, lib.AV_OPT_TYPE_FLOAT,
-                                 lib.AV_OPT_TYPE_RATIONAL):
-                return self.ptr.default_val.dbl
-            if self.ptr.type in (lib.AV_OPT_TYPE_STRING, lib.AV_OPT_TYPE_BINARY,
-                                 lib.AV_OPT_TYPE_IMAGE_SIZE, lib.AV_OPT_TYPE_VIDEO_RATE,
-                                 lib.AV_OPT_TYPE_COLOR):
-                return self.ptr.default_val.str if self.ptr.default_val.str != NULL else ""
+    @property
+    def default(self):
+        if self.ptr.type in _INT_TYPES:
+            return self.ptr.default_val.i64
+        if self.ptr.type in (lib.AV_OPT_TYPE_DOUBLE, lib.AV_OPT_TYPE_FLOAT,
+                             lib.AV_OPT_TYPE_RATIONAL):
+            return self.ptr.default_val.dbl
+        if self.ptr.type in (lib.AV_OPT_TYPE_STRING, lib.AV_OPT_TYPE_BINARY,
+                             lib.AV_OPT_TYPE_IMAGE_SIZE, lib.AV_OPT_TYPE_VIDEO_RATE,
+                             lib.AV_OPT_TYPE_COLOR):
+            return self.ptr.default_val.str if self.ptr.default_val.str != NULL else ""
 
     def _norm_range(self, value):
         if self.ptr.type in _INT_TYPES:
             return int(value)
         return value
 
-    property min:
-        def __get__(self):
-            return self._norm_range(self.ptr.min)
+    @property
+    def min(self):
+        return self._norm_range(self.ptr.min)
 
-    property max:
-        def __get__(self):
-            return self._norm_range(self.ptr.max)
+    @property
+    def max(self):
+        return self._norm_range(self.ptr.max)
 
     def __repr__(self):
         return (
@@ -164,9 +164,9 @@ cdef class OptionChoice(BaseOption):
     choices of non-const option with same unit.
     """
 
-    property value:
-        def __get__(self):
-            return self.ptr.default_val.i64
+    @property
+    def value(self):
+        return self.ptr.default_val.i64
 
     def __repr__(self):
         return f"<av.{self.__class__.__name__} {self.name} at 0x{id(self):x}>"

--- a/av/packet.pyx
+++ b/av/packet.pyx
@@ -94,34 +94,37 @@ cdef class Packet(Buffer):
         res = self._stream.decode(self)
         return res[0] if res else None
 
-    property stream_index:
-        def __get__(self):
-            return self.ptr.stream_index
+    @property
+    def stream_index(self):
+        return self.ptr.stream_index
 
-    property stream:
+    @property
+    def stream(self):
         """
         The :class:`Stream` this packet was demuxed from.
         """
-        def __get__(self):
-            return self._stream
+        return self._stream
 
-        def __set__(self, Stream stream):
-            self._stream = stream
-            self.ptr.stream_index = stream.ptr.index
+    @stream.setter
+    def stream(self, Stream stream):
+        self._stream = stream
+        self.ptr.stream_index = stream.ptr.index
 
-    property time_base:
+    @property
+    def time_base(self):
         """
         The unit of time (in fractional seconds) in which timestamps are expressed.
 
         :type: fractions.Fraction
         """
-        def __get__(self):
-            return avrational_to_fraction(&self._time_base)
+        return avrational_to_fraction(&self._time_base)
 
-        def __set__(self, value):
-            to_avrational(value, &self._time_base)
+    @time_base.setter
+    def time_base(self, value):
+        to_avrational(value, &self._time_base)
 
-    property pts:
+    @property
+    def pts(self):
         """
         The presentation timestamp in :attr:`time_base` units for this packet.
 
@@ -129,33 +132,35 @@ cdef class Packet(Buffer):
 
         :type: int
         """
-        def __get__(self):
-            if self.ptr.pts != lib.AV_NOPTS_VALUE:
-                return self.ptr.pts
+        if self.ptr.pts != lib.AV_NOPTS_VALUE:
+            return self.ptr.pts
 
-        def __set__(self, v):
-            if v is None:
-                self.ptr.pts = lib.AV_NOPTS_VALUE
-            else:
-                self.ptr.pts = v
+    @pts.setter
+    def pts(self, v):
+        if v is None:
+            self.ptr.pts = lib.AV_NOPTS_VALUE
+        else:
+            self.ptr.pts = v
 
-    property dts:
+    @property
+    def dts(self):
         """
         The decoding timestamp in :attr:`time_base` units for this packet.
 
         :type: int
         """
-        def __get__(self):
-            if self.ptr.dts != lib.AV_NOPTS_VALUE:
-                return self.ptr.dts
+        if self.ptr.dts != lib.AV_NOPTS_VALUE:
+            return self.ptr.dts
 
-        def __set__(self, v):
-            if v is None:
-                self.ptr.dts = lib.AV_NOPTS_VALUE
-            else:
-                self.ptr.dts = v
+    @dts.setter
+    def dts(self, v):
+        if v is None:
+            self.ptr.dts = lib.AV_NOPTS_VALUE
+        else:
+            self.ptr.dts = v
 
-    property pos:
+    @property
+    def pos(self):
         """
         The byte position of this packet within the :class:`.Stream`.
 
@@ -163,20 +168,20 @@ cdef class Packet(Buffer):
 
         :type: int
         """
-        def __get__(self):
-            if self.ptr.pos != -1:
-                return self.ptr.pos
+        if self.ptr.pos != -1:
+            return self.ptr.pos
 
-    property size:
+    @property
+    def size(self):
         """
         The size in bytes of this packet's data.
 
         :type: int
         """
-        def __get__(self):
-            return self.ptr.size
+        return self.ptr.size
 
-    property duration:
+    @property
+    def duration(self):
         """
         The duration in :attr:`time_base` units for this packet.
 
@@ -184,24 +189,26 @@ cdef class Packet(Buffer):
 
         :type: int
         """
-        def __get__(self):
-            if self.ptr.duration != lib.AV_NOPTS_VALUE:
-                return self.ptr.duration
+        if self.ptr.duration != lib.AV_NOPTS_VALUE:
+            return self.ptr.duration
 
-    property is_keyframe:
-        def __get__(self): return bool(self.ptr.flags & lib.AV_PKT_FLAG_KEY)
+    @property
+    def is_keyframe(self):
+        return bool(self.ptr.flags & lib.AV_PKT_FLAG_KEY)
 
-        def __set__(self, v):
-            if v:
-                self.ptr.flags |= lib.AV_PKT_FLAG_KEY
-            else:
-                self.ptr.flags &= ~(lib.AV_PKT_FLAG_KEY)
+    @is_keyframe.setter
+    def is_keyframe(self, v):
+        if v:
+            self.ptr.flags |= lib.AV_PKT_FLAG_KEY
+        else:
+            self.ptr.flags &= ~(lib.AV_PKT_FLAG_KEY)
 
-    property is_corrupt:
-        def __get__(self): return bool(self.ptr.flags & lib.AV_PKT_FLAG_CORRUPT)
+    @property
+    def is_corrupt(self): return bool(self.ptr.flags & lib.AV_PKT_FLAG_CORRUPT)
 
-        def __set__(self, v):
-            if v:
-                self.ptr.flags |= lib.AV_PKT_FLAG_CORRUPT
-            else:
-                self.ptr.flags &= ~(lib.AV_PKT_FLAG_CORRUPT)
+    @is_corrupt.setter
+    def is_corrupt(self, v):
+        if v:
+            self.ptr.flags |= lib.AV_PKT_FLAG_CORRUPT
+        else:
+            self.ptr.flags &= ~(lib.AV_PKT_FLAG_CORRUPT)

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -193,15 +193,15 @@ cdef class Stream:
 
         return nb_side_data, side_data
 
-    property id:
+    @property
+    def id(self):
         """
         The format-specific ID of this stream.
 
         :type: int
 
         """
-        def __get__(self):
-            return self.ptr.id
+        return self.ptr.id
 
     cdef _set_id(self, value):
         """
@@ -212,35 +212,37 @@ cdef class Stream:
         else:
             self.ptr.id = value
 
-    property profile:
+    @property
+    def profile(self):
         """
         The profile of this stream.
 
         :type: str
         """
-        def __get__(self):
-            if self.codec_context:
-                return self.codec_context.profile
-            else:
-                return None
+        if self.codec_context:
+            return self.codec_context.profile
+        else:
+            return None
 
-    property index:
+    @property
+    def index(self):
         """
         The index of this stream in its :class:`.Container`.
 
         :type: int
         """
-        def __get__(self): return self.ptr.index
+        return self.ptr.index
 
-    property time_base:
+
+    @property
+    def time_base(self):
         """
         The unit of time (in fractional seconds) in which timestamps are expressed.
 
         :type: :class:`~fractions.Fraction` or ``None``
 
         """
-        def __get__(self):
-            return avrational_to_fraction(&self.ptr.time_base)
+        return avrational_to_fraction(&self.ptr.time_base)
 
     cdef _set_time_base(self, value):
         """
@@ -248,7 +250,8 @@ cdef class Stream:
         """
         to_avrational(value, &self.ptr.time_base)
 
-    property average_rate:
+    @property
+    def average_rate(self):
         """
         The average frame rate of this video stream.
 
@@ -259,10 +262,10 @@ cdef class Stream:
 
 
         """
-        def __get__(self):
-            return avrational_to_fraction(&self.ptr.avg_frame_rate)
+        return avrational_to_fraction(&self.ptr.avg_frame_rate)
 
-    property base_rate:
+    @property
+    def base_rate(self):
         """
         The base frame rate of this stream.
 
@@ -273,10 +276,10 @@ cdef class Stream:
         :type: :class:`~fractions.Fraction` or ``None``
 
         """
-        def __get__(self):
-            return avrational_to_fraction(&self.ptr.r_frame_rate)
+        return avrational_to_fraction(&self.ptr.r_frame_rate)
 
-    property guessed_rate:
+    @property
+    def guessed_rate(self):
         """The guessed frame rate of this stream.
 
         This is a wrapper around :ffmpeg:`av_guess_frame_rate`, and uses multiple
@@ -285,34 +288,34 @@ cdef class Stream:
         :type: :class:`~fractions.Fraction` or ``None``
 
         """
-        def __get__(self):
-            # The two NULL arguments aren't used in FFmpeg >= 4.0
-            cdef lib.AVRational val = lib.av_guess_frame_rate(NULL, self.ptr, NULL)
-            return avrational_to_fraction(&val)
+        # The two NULL arguments aren't used in FFmpeg >= 4.0
+        cdef lib.AVRational val = lib.av_guess_frame_rate(NULL, self.ptr, NULL)
+        return avrational_to_fraction(&val)
 
-    property start_time:
+    @property
+    def start_time(self):
         """
         The presentation timestamp in :attr:`time_base` units of the first
         frame in this stream.
 
         :type: :class:`int` or ``None``
         """
-        def __get__(self):
-            if self.ptr.start_time != lib.AV_NOPTS_VALUE:
-                return self.ptr.start_time
+        if self.ptr.start_time != lib.AV_NOPTS_VALUE:
+            return self.ptr.start_time
 
-    property duration:
+    @property
+    def duration(self):
         """
         The duration of this stream in :attr:`time_base` units.
 
         :type: :class:`int` or ``None``
 
         """
-        def __get__(self):
-            if self.ptr.duration != lib.AV_NOPTS_VALUE:
-                return self.ptr.duration
+        if self.ptr.duration != lib.AV_NOPTS_VALUE:
+            return self.ptr.duration
 
-    property frames:
+    @property
+    def frames(self):
         """
         The number of frames this stream contains.
 
@@ -320,17 +323,16 @@ cdef class Stream:
 
         :type: :class:`int`
         """
-        def __get__(self):
-            return self.ptr.nb_frames
+        return self.ptr.nb_frames
 
-    property language:
+    @property
+    def language(self):
         """
         The language of the stream.
 
         :type: :class:`str` or ``None``
         """
-        def __get__(self):
-            return self.metadata.get('language')
+        return self.metadata.get('language')
 
     @property
     def type(self):


### PR DESCRIPTION
"Showing 24 changed files with 907 additions and 843 deletions."
I doubt that you want this all in one PR, so I broke it up into more manageable chunks.

We currently use a legacy syntax for defining properties in an extension class which has been deprecated since ~2016:
https://cython.readthedocs.io/en/stable/src/userguide/extension_types.html#properties

Switching to the new syntax required moving the property docstrings. Previously, the docstring was placed on the line below the `property` keyword. However, using the new syntax there can not be anything between the decorator and the `def` statement, so the docstring was moved to below the def statement.
