### PR TITLE
Convert Cython extension class properties to decorator syntax part 2 of 4

### DIFF
--- a/av/audio/codeccontext.pyx
+++ b/av/audio/codeccontext.pyx
@@ -53,69 +53,76 @@ cdef class AudioCodecContext(CodecContext):
         cdef AudioFrame aframe = frame
         aframe._init_user_attributes()
 
-    property frame_size:
+    @property
+    def frame_size(self):
         """
         Number of samples per channel in an audio frame.
 
         :type: int
         """
-        def __get__(self): return self.ptr.frame_size
+        return self.ptr.frame_size
 
-    property sample_rate:
+
+    @property
+    def sample_rate(self):
         """
         Sample rate of the audio data, in samples per second.
 
         :type: int
         """
-        def __get__(self):
-            return self.ptr.sample_rate
+        return self.ptr.sample_rate
 
-        def __set__(self, int value):
-            self.ptr.sample_rate = value
+    @sample_rate.setter
+    def sample_rate(self, int value):
+        self.ptr.sample_rate = value
 
-    property rate:
+    @property
+    def rate(self):
         """Another name for :attr:`sample_rate`."""
-        def __get__(self):
-            return self.sample_rate
+        return self.sample_rate
 
-        def __set__(self, value):
-            self.sample_rate = value
+    @rate.setter
+    def rate(self, value):
+        self.sample_rate = value
 
     # TODO: Integrate into AudioLayout.
-    property channels:
-        def __get__(self):
-            return self.ptr.channels
+    @property
+    def channels(self):
+        return self.ptr.channels
 
-        def __set__(self, value):
-            self.ptr.channels = value
-            self.ptr.channel_layout = lib.av_get_default_channel_layout(value)
-    property channel_layout:
-        def __get__(self):
-            return self.ptr.channel_layout
+    @channels.setter
+    def channels(self, value):
+        self.ptr.channels = value
+        self.ptr.channel_layout = lib.av_get_default_channel_layout(value)
+    @property
+    def channel_layout(self):
+        return self.ptr.channel_layout
 
-    property layout:
+    @property
+    def layout(self):
         """
         The audio channel layout.
 
         :type: AudioLayout
         """
-        def __get__(self):
-            return get_audio_layout(self.ptr.channels, self.ptr.channel_layout)
+        return get_audio_layout(self.ptr.channels, self.ptr.channel_layout)
 
-        def __set__(self, value):
-            cdef AudioLayout layout = AudioLayout(value)
-            self.ptr.channel_layout = layout.layout
-            self.ptr.channels = layout.nb_channels
+    @layout.setter
+    def layout(self, value):
+        cdef AudioLayout layout = AudioLayout(value)
+        self.ptr.channel_layout = layout.layout
+        self.ptr.channels = layout.nb_channels
 
-    property format:
+    @property
+    def format(self):
         """
         The audio sample format.
 
         :type: AudioFormat
         """
-        def __get__(self):
-            return get_audio_format(self.ptr.sample_fmt)
+        return get_audio_format(self.ptr.sample_fmt)
 
-        def __set__(self, value):
-            cdef AudioFormat format = AudioFormat(value)
-            self.ptr.sample_fmt = format.sample_fmt
+    @format.setter
+    def format(self, value):
+        cdef AudioFormat format = AudioFormat(value)
+        self.ptr.sample_fmt = format.sample_fmt

--- a/av/audio/fifo.pyx
+++ b/av/audio/fifo.pyx
@@ -173,19 +173,19 @@ cdef class AudioFifo:
 
         return frames
 
-    property format:
+    @property
+    def format(self):
         """The :class:`.AudioFormat` of this FIFO."""
-        def __get__(self):
-            return self.template.format
-    property layout:
+        return self.template.format
+    @property
+    def layout(self):
         """The :class:`.AudioLayout` of this FIFO."""
-        def __get__(self):
-            return self.template.layout
-    property sample_rate:
-        def __get__(self):
-            return self.template.sample_rate
+        return self.template.layout
+    @property
+    def sample_rate(self):
+        return self.template.sample_rate
 
-    property samples:
+    @property
+    def samples(self):
         """Number of audio samples (per channel) in the buffer."""
-        def __get__(self):
-            return lib.av_audio_fifo_size(self.ptr) if self.ptr else 0
+        return lib.av_audio_fifo_size(self.ptr) if self.ptr else 0

--- a/av/audio/format.pyx
+++ b/av/audio/format.pyx
@@ -41,70 +41,72 @@ cdef class AudioFormat:
     def __repr__(self):
         return f"<av.AudioFormat {self.name}>"
 
-    property name:
+    @property
+    def name(self):
         """Canonical name of the sample format.
 
         >>> SampleFormat('s16p').name
         's16p'
 
         """
-        def __get__(self):
-            return <str>lib.av_get_sample_fmt_name(self.sample_fmt)
+        return <str>lib.av_get_sample_fmt_name(self.sample_fmt)
 
-    property bytes:
+    @property
+    def bytes(self):
         """Number of bytes per sample.
 
         >>> SampleFormat('s16p').bytes
         2
 
         """
-        def __get__(self):
-            return lib.av_get_bytes_per_sample(self.sample_fmt)
+        return lib.av_get_bytes_per_sample(self.sample_fmt)
 
-    property bits:
+    @property
+    def bits(self):
         """Number of bits per sample.
 
         >>> SampleFormat('s16p').bits
         16
 
         """
-        def __get__(self):
-            return lib.av_get_bytes_per_sample(self.sample_fmt) << 3
+        return lib.av_get_bytes_per_sample(self.sample_fmt) << 3
 
-    property is_planar:
+    @property
+    def is_planar(self):
         """Is this a planar format?
 
         Strictly opposite of :attr:`is_packed`.
 
         """
-        def __get__(self):
-            return bool(lib.av_sample_fmt_is_planar(self.sample_fmt))
+        return bool(lib.av_sample_fmt_is_planar(self.sample_fmt))
 
-    property is_packed:
+    @property
+    def is_packed(self):
         """Is this a planar format?
 
         Strictly opposite of :attr:`is_planar`.
 
         """
-        def __get__(self):
-            return not lib.av_sample_fmt_is_planar(self.sample_fmt)
+        return not lib.av_sample_fmt_is_planar(self.sample_fmt)
 
-    property planar:
+    @property
+    def planar(self):
         """The planar variant of this format.
 
         Is itself when planar:
 
+        >>> from av import AudioFormat as Format
         >>> fmt = Format('s16p')
         >>> fmt.planar is fmt
         True
 
         """
-        def __get__(self):
-            if self.is_planar:
-                return self
-            return get_audio_format(lib.av_get_planar_sample_fmt(self.sample_fmt))
+        if self.is_planar:
+            return self
+        return get_audio_format(lib.av_get_planar_sample_fmt(self.sample_fmt))
 
-    property packed:
+    @property
+    def packed(self):
         """The packed variant of this format.
 
         Is itself when packed:
@@ -114,30 +116,29 @@ cdef class AudioFormat:
         True
 
         """
-        def __get__(self):
-            if self.is_packed:
-                return self
-            return get_audio_format(lib.av_get_packed_sample_fmt(self.sample_fmt))
+        if self.is_packed:
+            return self
+        return get_audio_format(lib.av_get_packed_sample_fmt(self.sample_fmt))
 
-    property container_name:
+    @property
+    def container_name(self):
         """The name of a :class:`ContainerFormat` which directly accepts this data.
 
         :raises ValueError: when planar, since there are no such containers.
 
         """
-        def __get__(self):
-            if self.is_planar:
-                raise ValueError("no planar container formats")
+        if self.is_planar:
+            raise ValueError("no planar container formats")
 
-            if self.sample_fmt == lib.AV_SAMPLE_FMT_U8:
-                return "u8"
-            elif self.sample_fmt == lib.AV_SAMPLE_FMT_S16:
-                return "s16" + container_format_postfix
-            elif self.sample_fmt == lib.AV_SAMPLE_FMT_S32:
-                return "s32" + container_format_postfix
-            elif self.sample_fmt == lib.AV_SAMPLE_FMT_FLT:
-                return "f32" + container_format_postfix
-            elif self.sample_fmt == lib.AV_SAMPLE_FMT_DBL:
-                return "f64" + container_format_postfix
+        if self.sample_fmt == lib.AV_SAMPLE_FMT_U8:
+            return "u8"
+        elif self.sample_fmt == lib.AV_SAMPLE_FMT_S16:
+            return "s16" + container_format_postfix
+        elif self.sample_fmt == lib.AV_SAMPLE_FMT_S32:
+            return "s32" + container_format_postfix
+        elif self.sample_fmt == lib.AV_SAMPLE_FMT_FLT:
+            return "f32" + container_format_postfix
+        elif self.sample_fmt == lib.AV_SAMPLE_FMT_DBL:
+            return "f64" + container_format_postfix
 
-            raise ValueError("unknown layout")
+        raise ValueError("unknown layout")

--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -141,34 +141,36 @@ cdef class AudioFrame(Frame):
 
         return tuple([AudioPlane(self, i) for i in range(plane_count)])
 
-    property samples:
+    @property
+    def samples(self):
         """
         Number of audio samples (per channel).
 
         :type: int
         """
-        def __get__(self):
-            return self.ptr.nb_samples
+        return self.ptr.nb_samples
 
-    property sample_rate:
+    @property
+    def sample_rate(self):
         """
         Sample rate of the audio data, in samples per second.
 
         :type: int
         """
-        def __get__(self):
-            return self.ptr.sample_rate
+        return self.ptr.sample_rate
 
-        def __set__(self, value):
-            self.ptr.sample_rate = value
+    @sample_rate.setter
+    def sample_rate(self, value):
+        self.ptr.sample_rate = value
 
-    property rate:
+    @property
+    def rate(self):
         """Another name for :attr:`sample_rate`."""
-        def __get__(self):
-            return self.ptr.sample_rate
+        return self.ptr.sample_rate
 
-        def __set__(self, value):
-            self.ptr.sample_rate = value
+    @rate.setter
+    def rate(self, value):
+        self.ptr.sample_rate = value
 
     def to_ndarray(self, **kwargs):
         """Get a numpy array of this frame.

--- a/av/audio/layout.pyx
+++ b/av/audio/layout.pyx
@@ -93,13 +93,13 @@ cdef class AudioLayout:
     def __repr__(self):
         return f"<av.{self.__class__.__name__} {self.name!r}>"
 
-    property name:
+    @property
+    def name(self):
         """The canonical name of the audio layout."""
-        def __get__(self):
-            cdef char out[32]
-            # Passing 0 as number of channels... fix this later?
-            lib.av_get_channel_layout_string(out, 32, 0, self.layout)
-            return <str>out
+        cdef char out[32]
+        # Passing 0 as number of channels... fix this later?
+        lib.av_get_channel_layout_string(out, 32, 0, self.layout)
+        return <str>out
 
 
 cdef class AudioChannel:
@@ -109,12 +109,12 @@ cdef class AudioChannel:
     def __repr__(self):
         return f"<av.{self.__class__.__name__} {self.name!r} ({self.description})>"
 
-    property name:
+    @property
+    def name(self):
         """The canonical name of the audio channel."""
-        def __get__(self):
-            return lib.av_get_channel_name(self.channel)
+        return lib.av_get_channel_name(self.channel)
 
-    property description:
+    @property
+    def description(self):
         """A human description of the audio channel."""
-        def __get__(self):
-            return channel_descriptions.get(self.name)
+        return channel_descriptions.get(self.name)


### PR DESCRIPTION
I received this error when running the doctests on the `planar` property in av/audio/format.pyx:
`NameError: name 'Format' is not defined`

It was solved by including this:
`>>> from av import AudioFormat as Format`