### PR TITLE
Convert deprecated cython extension class properties to new syntax part 3

### DIFF
--- a/av/data/stream.pyx
+++ b/av/data/stream.pyx
@@ -15,9 +15,9 @@ cdef class DataStream(Stream):
     def decode(self, packet=None, count=0):
         return []
 
-    property name:
-        def __get__(self):
-            cdef const lib.AVCodecDescriptor *desc = lib.avcodec_descriptor_get(self.ptr.codecpar.codec_id)
-            if desc == NULL:
-                return None
-            return desc.name
+    @property
+    def name(self):
+        cdef const lib.AVCodecDescriptor *desc = lib.avcodec_descriptor_get(self.ptr.codecpar.codec_id)
+        if desc == NULL:
+            return None
+        return desc.name

--- a/av/filter/context.pyx
+++ b/av/filter/context.pyx
@@ -33,22 +33,22 @@ cdef class FilterContext:
         parent = self.filter.ptr.name if self.filter and self.filter.ptr != NULL else None
         return f"<av.FilterContext {name} of {parent!r} at 0x{id(self):x}>"
 
-    property name:
-        def __get__(self):
-            if self.ptr.name != NULL:
-                return self.ptr.name
+    @property
+    def name(self):
+        if self.ptr.name != NULL:
+            return self.ptr.name
 
-    property inputs:
-        def __get__(self):
-            if self._inputs is None:
-                self._inputs = alloc_filter_pads(self.filter, self.ptr.input_pads, True, self)
-            return self._inputs
+    @property
+    def inputs(self):
+        if self._inputs is None:
+            self._inputs = alloc_filter_pads(self.filter, self.ptr.input_pads, True, self)
+        return self._inputs
 
-    property outputs:
-        def __get__(self):
-            if self._outputs is None:
-                self._outputs = alloc_filter_pads(self.filter, self.ptr.output_pads, False, self)
-            return self._outputs
+    @property
+    def outputs(self):
+        if self._outputs is None:
+            self._outputs = alloc_filter_pads(self.filter, self.ptr.output_pads, False, self)
+        return self._outputs
 
     def init(self, args=None, **kwargs):
         if self.inited:

--- a/av/filter/filter.pyx
+++ b/av/filter/filter.pyx
@@ -31,61 +31,61 @@ cdef class Filter:
         if not self.ptr:
             raise ValueError(f"no filter {name}")
 
-    property descriptor:
-        def __get__(self):
-            if self._descriptor is None:
-                self._descriptor = wrap_avclass(self.ptr.priv_class)
-            return self._descriptor
+    @property
+    def descriptor(self):
+        if self._descriptor is None:
+            self._descriptor = wrap_avclass(self.ptr.priv_class)
+        return self._descriptor
 
-    property options:
-        def __get__(self):
-            if self.descriptor is None:
-                return
-            return self.descriptor.options
+    @property
+    def options(self):
+        if self.descriptor is None:
+            return
+        return self.descriptor.options
 
-    property name:
-        def __get__(self):
-            return self.ptr.name
+    @property
+    def name(self):
+        return self.ptr.name
 
-    property description:
-        def __get__(self):
-            return self.ptr.description
+    @property
+    def description(self):
+        return self.ptr.description
 
-    property flags:
-        def __get__(self):
-            return self.ptr.flags
+    @property
+    def flags(self):
+        return self.ptr.flags
 
-    property dynamic_inputs:
-        def __get__(self):
-            return bool(self.ptr.flags & lib.AVFILTER_FLAG_DYNAMIC_INPUTS)
+    @property
+    def dynamic_inputs(self):
+        return bool(self.ptr.flags & lib.AVFILTER_FLAG_DYNAMIC_INPUTS)
 
-    property dynamic_outputs:
-        def __get__(self):
-            return bool(self.ptr.flags & lib.AVFILTER_FLAG_DYNAMIC_OUTPUTS)
+    @property
+    def dynamic_outputs(self):
+        return bool(self.ptr.flags & lib.AVFILTER_FLAG_DYNAMIC_OUTPUTS)
 
-    property timeline_support:
-        def __get__(self):
-            return bool(self.ptr.flags & lib.AVFILTER_FLAG_SUPPORT_TIMELINE_GENERIC)
+    @property
+    def timeline_support(self):
+        return bool(self.ptr.flags & lib.AVFILTER_FLAG_SUPPORT_TIMELINE_GENERIC)
 
-    property slice_threads:
-        def __get__(self):
-            return bool(self.ptr.flags & lib.AVFILTER_FLAG_SLICE_THREADS)
+    @property
+    def slice_threads(self):
+        return bool(self.ptr.flags & lib.AVFILTER_FLAG_SLICE_THREADS)
 
-    property command_support:
-        def __get__(self):
-            return self.ptr.process_command != NULL
+    @property
+    def command_support(self):
+        return self.ptr.process_command != NULL
 
-    property inputs:
-        def __get__(self):
-            if self._inputs is None:
-                self._inputs = alloc_filter_pads(self, self.ptr.inputs, True)
-            return self._inputs
+    @property
+    def inputs(self):
+        if self._inputs is None:
+            self._inputs = alloc_filter_pads(self, self.ptr.inputs, True)
+        return self._inputs
 
-    property outputs:
-        def __get__(self):
-            if self._outputs is None:
-                self._outputs = alloc_filter_pads(self, self.ptr.outputs, False)
-            return self._outputs
+    @property
+    def outputs(self):
+        if self._outputs is None:
+            self._outputs = alloc_filter_pads(self, self.ptr.outputs, False)
+        return self._outputs
 
 
 cdef get_filter_names():

--- a/av/filter/link.pyx
+++ b/av/filter/link.pyx
@@ -12,38 +12,38 @@ cdef class FilterLink:
         if sentinel is not _cinit_sentinel:
             raise RuntimeError("cannot instantiate FilterLink")
 
-    property input:
-        def __get__(self):
-            if self._input:
-                return self._input
-            cdef lib.AVFilterContext *cctx = self.ptr.src
-            cdef unsigned int i
-            for i in range(cctx.nb_outputs):
-                if self.ptr == cctx.outputs[i]:
-                    break
-            else:
-                raise RuntimeError("could not find link in context")
-            ctx = self.graph._context_by_ptr[<long>cctx]
-            self._input = ctx.outputs[i]
+    @property
+    def input(self):
+        if self._input:
             return self._input
+        cdef lib.AVFilterContext *cctx = self.ptr.src
+        cdef unsigned int i
+        for i in range(cctx.nb_outputs):
+            if self.ptr == cctx.outputs[i]:
+                break
+        else:
+            raise RuntimeError("could not find link in context")
+        ctx = self.graph._context_by_ptr[<long>cctx]
+        self._input = ctx.outputs[i]
+        return self._input
 
-    property output:
-        def __get__(self):
-            if self._output:
-                return self._output
-            cdef lib.AVFilterContext *cctx = self.ptr.dst
-            cdef unsigned int i
-            for i in range(cctx.nb_inputs):
-                if self.ptr == cctx.inputs[i]:
-                    break
-            else:
-                raise RuntimeError("could not find link in context")
-            try:
-                ctx = self.graph._context_by_ptr[<long>cctx]
-            except KeyError:
-                raise RuntimeError("could not find context in graph", (cctx.name, cctx.filter.name))
-            self._output = ctx.inputs[i]
+    @property
+    def output(self):
+        if self._output:
             return self._output
+        cdef lib.AVFilterContext *cctx = self.ptr.dst
+        cdef unsigned int i
+        for i in range(cctx.nb_inputs):
+            if self.ptr == cctx.inputs[i]:
+                break
+        else:
+            raise RuntimeError("could not find link in context")
+        try:
+            ctx = self.graph._context_by_ptr[<long>cctx]
+        except KeyError:
+            raise RuntimeError("could not find context in graph", (cctx.name, cctx.filter.name))
+        self._output = ctx.inputs[i]
+        return self._output
 
 
 cdef FilterLink wrap_filter_link(Graph graph, lib.AVFilterLink *ptr):

--- a/av/filter/pad.pyx
+++ b/av/filter/pad.pyx
@@ -15,13 +15,13 @@ cdef class FilterPad:
 
         return f"<av.FilterPad {_filter}.{_io}[{self.index}]: {self.name} ({self.type})>"
 
-    property is_output:
-        def __get__(self):
-            return not self.is_input
+    @property
+    def is_output(self):
+        return not self.is_input
 
-    property name:
-        def __get__(self):
-            return lib.avfilter_pad_get_name(self.base_ptr, self.index)
+    @property
+    def name(self):
+        return lib.avfilter_pad_get_name(self.base_ptr, self.index)
 
     @property
     def type(self):
@@ -43,22 +43,22 @@ cdef class FilterContextPad(FilterPad):
 
         return f"<av.FilterContextPad {_filter}.{_io}[{self.index}] of {context}: {self.name} ({self.type})>"
 
-    property link:
-        def __get__(self):
-            if self._link:
-                return self._link
-            cdef lib.AVFilterLink **links = self.context.ptr.inputs if self.is_input else self.context.ptr.outputs
-            cdef lib.AVFilterLink *link = links[self.index]
-            if not link:
-                return
-            self._link = wrap_filter_link(self.context.graph, link)
+    @property
+    def link(self):
+        if self._link:
             return self._link
+        cdef lib.AVFilterLink **links = self.context.ptr.inputs if self.is_input else self.context.ptr.outputs
+        cdef lib.AVFilterLink *link = links[self.index]
+        if not link:
+            return
+        self._link = wrap_filter_link(self.context.graph, link)
+        return self._link
 
-    property linked:
-        def __get__(self):
-            cdef FilterLink link = self.link
-            if link:
-                return link.input if self.is_input else link.output
+    @property
+    def linked(self):
+        cdef FilterLink link = self.link
+        if link:
+            return link.input if self.is_input else link.output
 
 
 cdef tuple alloc_filter_pads(Filter filter, const lib.AVFilterPad *ptr, bint is_input, FilterContext context=None):

--- a/av/subtitles/subtitle.pyx
+++ b/av/subtitles/subtitle.pyx
@@ -20,14 +20,14 @@ cdef class SubtitleSet:
             id(self),
         )
 
-    property format:
-        def __get__(self): return self.proxy.struct.format
-    property start_display_time:
-        def __get__(self): return self.proxy.struct.start_display_time
-    property end_display_time:
-        def __get__(self): return self.proxy.struct.end_display_time
-    property pts:
-        def __get__(self): return self.proxy.struct.pts
+    @property
+    def format(self): return self.proxy.struct.format
+    @property
+    def start_display_time(self): return self.proxy.struct.start_display_time
+    @property
+    def end_display_time(self): return self.proxy.struct.end_display_time
+    @property
+    def pts(self): return self.proxy.struct.pts
 
     def __len__(self):
         return len(self.rects)
@@ -110,16 +110,16 @@ cdef class BitmapSubtitle(Subtitle):
             id(self),
         )
 
-    property x:
-        def __get__(self): return self.ptr.x
-    property y:
-        def __get__(self): return self.ptr.y
-    property width:
-        def __get__(self): return self.ptr.w
-    property height:
-        def __get__(self): return self.ptr.h
-    property nb_colors:
-        def __get__(self): return self.ptr.nb_colors
+    @property
+    def x(self): return self.ptr.x
+    @property
+    def y(self): return self.ptr.y
+    @property
+    def width(self): return self.ptr.w
+    @property
+    def height(self): return self.ptr.h
+    @property
+    def nb_colors(self): return self.ptr.nb_colors
 
     def __len__(self):
         return len(self.planes)
@@ -161,8 +161,8 @@ cdef class TextSubtitle(Subtitle):
             id(self),
         )
 
-    property text:
-        def __get__(self): return self.ptr.text
+    @property
+    def text(self): return self.ptr.text
 
 
 cdef class AssSubtitle(Subtitle):
@@ -175,5 +175,5 @@ cdef class AssSubtitle(Subtitle):
             id(self),
         )
 
-    property ass:
-        def __get__(self): return self.ptr.ass
+    @property
+    def ass(self): return self.ptr.ass


### PR DESCRIPTION
WyattBlue, I saw a note you made here:
https://github.com/PyAV-Org/PyAV/wiki/TODO-general
"Convert properties to decorator syntax. This will also allow doctest to run on them."

Could you explain what you meant by this? Is doctest incompatible with the old syntax?