### PR TITLE
Convert deprecated cython extension class properties to new syntax part 4

### DIFF
--- a/av/codec/codec.pyx
+++ b/av/codec/codec.pyx
@@ -209,17 +209,17 @@ cdef class Codec:
         from .context import CodecContext
         return CodecContext.create(self)
 
-    property is_decoder:
-        def __get__(self):
-            return not self.is_encoder
+    @property
+    def is_decoder(self):
+        return not self.is_encoder
 
-    property descriptor:
-        def __get__(self): return wrap_avclass(self.ptr.priv_class)
+    @property
+    def descriptor(self): return wrap_avclass(self.ptr.priv_class)
 
-    property name:
-        def __get__(self): return self.ptr.name or ""
-    property long_name:
-        def __get__(self): return self.ptr.long_name or ""
+    @property
+    def name(self): return self.ptr.name or ""
+    @property
+    def long_name(self): return self.ptr.long_name or ""
 
     @property
     def type(self):
@@ -231,8 +231,8 @@ cdef class Codec:
         """
         return lib.av_get_media_type_string(self.ptr.type)
 
-    property id:
-        def __get__(self): return self.ptr.id
+    @property
+    def id(self): return self.ptr.id
 
     @property
     def frame_rates(self):

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -87,27 +87,27 @@ cdef class InputContainer(Container):
     def __dealloc__(self):
         close_input(self)
 
-    property start_time:
-        def __get__(self):
-            self._assert_open()
-            if self.ptr.start_time != lib.AV_NOPTS_VALUE:
-                return self.ptr.start_time
+    @property
+    def start_time(self):
+        self._assert_open()
+        if self.ptr.start_time != lib.AV_NOPTS_VALUE:
+            return self.ptr.start_time
 
-    property duration:
-        def __get__(self):
-            self._assert_open()
-            if self.ptr.duration != lib.AV_NOPTS_VALUE:
-                return self.ptr.duration
+    @property
+    def duration(self):
+        self._assert_open()
+        if self.ptr.duration != lib.AV_NOPTS_VALUE:
+            return self.ptr.duration
 
-    property bit_rate:
-        def __get__(self):
-            self._assert_open()
-            return self.ptr.bit_rate
+    @property
+    def bit_rate(self):
+        self._assert_open()
+        return self.ptr.bit_rate
 
-    property size:
-        def __get__(self):
-            self._assert_open()
-            return lib.avio_size(self.ptr.pb)
+    @property
+    def size(self):
+        self._assert_open()
+        return lib.avio_size(self.ptr.pb)
 
     def close(self):
         close_input(self)

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -70,116 +70,124 @@ cdef class VideoCodecContext(CodecContext):
     cdef _build_format(self):
         self._format = get_video_format(<lib.AVPixelFormat>self.ptr.pix_fmt, self.ptr.width, self.ptr.height)
 
-    property format:
-        def __get__(self):
-            return self._format
+    @property
+    def format(self):
+        return self._format
 
-        def __set__(self, VideoFormat format):
-            self.ptr.pix_fmt = format.pix_fmt
-            self.ptr.width = format.width
-            self.ptr.height = format.height
-            self._build_format()  # Kinda wasteful.
+    @format.setter
+    def format(self, VideoFormat format):
+        self.ptr.pix_fmt = format.pix_fmt
+        self.ptr.width = format.width
+        self.ptr.height = format.height
+        self._build_format()  # Kinda wasteful.
 
-    property width:
-        def __get__(self):
-            return self.ptr.width
+    @property
+    def width(self):
+        return self.ptr.width
 
-        def __set__(self, unsigned int value):
-            self.ptr.width = value
-            self._build_format()
+    @width.setter
+    def width(self, unsigned int value):
+        self.ptr.width = value
+        self._build_format()
 
-    property height:
-        def __get__(self):
-            return self.ptr.height
+    @property
+    def height(self):
+        return self.ptr.height
 
-        def __set__(self, unsigned int value):
-            self.ptr.height = value
-            self._build_format()
+    @height.setter
+    def height(self, unsigned int value):
+        self.ptr.height = value
+        self._build_format()
 
-    property pix_fmt:
+    @property
+    def pix_fmt(self):
         """
         The pixel format's name.
 
         :type: str
         """
-        def __get__(self):
-            return self._format.name
+        return self._format.name
 
-        def __set__(self, value):
-            self.ptr.pix_fmt = get_pix_fmt(value)
-            self._build_format()
+    @pix_fmt.setter
+    def pix_fmt(self, value):
+        self.ptr.pix_fmt = get_pix_fmt(value)
+        self._build_format()
 
-    property framerate:
+    @property
+    def framerate(self):
         """
         The frame rate, in frames per second.
 
         :type: fractions.Fraction
         """
-        def __get__(self):
-            return avrational_to_fraction(&self.ptr.framerate)
+        return avrational_to_fraction(&self.ptr.framerate)
 
-        def __set__(self, value):
-            to_avrational(value, &self.ptr.framerate)
+    @framerate.setter
+    def framerate(self, value):
+        to_avrational(value, &self.ptr.framerate)
 
-    property rate:
+    @property
+    def rate(self):
         """Another name for :attr:`framerate`."""
-        def __get__(self):
-            return self.framerate
+        return self.framerate
 
-        def __set__(self, value):
-            self.framerate = value
+    @rate.setter
+    def rate(self, value):
+        self.framerate = value
 
-    property gop_size:
+    @property
+    def gop_size(self):
         """
         Sets the number of frames between keyframes. Used only for encoding.
         
         :type: int
         """
-        def __get__(self):
-            if self.is_decoder:
-                warnings.warn(
-                    "Using VideoCodecContext.gop_size for decoders is deprecated.",
-                    AVDeprecationWarning
-                )
-            return self.ptr.gop_size
+        if self.is_decoder:
+            warnings.warn(
+                "Using VideoCodecContext.gop_size for decoders is deprecated.",
+                AVDeprecationWarning
+            )
+        return self.ptr.gop_size
 
-        def __set__(self, int value):
-            if self.is_decoder:
-                warnings.warn(
-                    "Using VideoCodecContext.gop_size for decoders is deprecated.",
-                    AVDeprecationWarning
-                )
-            self.ptr.gop_size = value
+    @gop_size.setter
+    def gop_size(self, int value):
+        if self.is_decoder:
+            warnings.warn(
+                "Using VideoCodecContext.gop_size for decoders is deprecated.",
+                AVDeprecationWarning
+            )
+        self.ptr.gop_size = value
 
-    property sample_aspect_ratio:
-        def __get__(self):
-            return avrational_to_fraction(&self.ptr.sample_aspect_ratio)
+    @property
+    def sample_aspect_ratio(self):
+        return avrational_to_fraction(&self.ptr.sample_aspect_ratio)
 
-        def __set__(self, value):
-            to_avrational(value, &self.ptr.sample_aspect_ratio)
+    @sample_aspect_ratio.setter
+    def sample_aspect_ratio(self, value):
+        to_avrational(value, &self.ptr.sample_aspect_ratio)
 
-    property display_aspect_ratio:
-        def __get__(self):
-            cdef lib.AVRational dar
+    @property
+    def display_aspect_ratio(self):
+        cdef lib.AVRational dar
 
-            lib.av_reduce(
-                &dar.num, &dar.den,
-                self.ptr.width * self.ptr.sample_aspect_ratio.num,
-                self.ptr.height * self.ptr.sample_aspect_ratio.den, 1024*1024)
+        lib.av_reduce(
+            &dar.num, &dar.den,
+            self.ptr.width * self.ptr.sample_aspect_ratio.num,
+            self.ptr.height * self.ptr.sample_aspect_ratio.den, 1024*1024)
 
-            return avrational_to_fraction(&dar)
+        return avrational_to_fraction(&dar)
 
-    property has_b_frames:
-        def __get__(self):
-            return bool(self.ptr.has_b_frames)
+    @property
+    def has_b_frames(self):
+        return bool(self.ptr.has_b_frames)
 
-    property coded_width:
-        def __get__(self):
-            return self.ptr.coded_width
+    @property
+    def coded_width(self):
+        return self.ptr.coded_width
 
-    property coded_height:
-        def __get__(self):
-            return self.ptr.coded_height
+    @property
+    def coded_height(self):
+        return self.ptr.coded_height
 
     @property
     def color_range(self):
@@ -188,20 +196,21 @@ cdef class VideoCodecContext(CodecContext):
 
         Wraps :ffmpeg:`AVFrame.color_range`.
         """
-        def __get__(self):
-            return self.ptr.color_range
+        return self.ptr.color_range
 
-        def __set__(self, value):
-            self.ptr.color_range = value
+    @color_range.setter
+    def color_range(self, value):
+        self.ptr.color_range = value
 
-    property max_b_frames:
+    @property
+    def max_b_frames(self):
         """
-	The maximum run of consecutive B frames when encoding a video.
+        The maximum run of consecutive B frames when encoding a video.
 
         :type: int
         """
-        def __get__(self):
-            return self.ptr.max_b_frames
+        return self.ptr.max_b_frames
 
-        def __set__(self, value):
-            self.ptr.max_b_frames = value
+    @max_b_frames.setter
+    def max_b_frames(self, value):
+        self.ptr.max_b_frames = value

--- a/av/video/format.pyx
+++ b/av/video/format.pyx
@@ -60,39 +60,50 @@ cdef class VideoFormat:
     def __int__(self):
         return int(self.pix_fmt)
 
-    property name:
+    @property
+    def name(self):
         """Canonical name of the pixel format."""
-        def __get__(self):
-            return <str>self.ptr.name
+        return <str>self.ptr.name
 
-    property bits_per_pixel:
-        def __get__(self): return lib.av_get_bits_per_pixel(self.ptr)
+    @property
+    def bits_per_pixel(self):
+        return lib.av_get_bits_per_pixel(self.ptr)
 
-    property padded_bits_per_pixel:
-        def __get__(self): return lib.av_get_padded_bits_per_pixel(self.ptr)
+    @property
+    def padded_bits_per_pixel(self): return lib.av_get_padded_bits_per_pixel(self.ptr)
 
-    property is_big_endian:
+    @property
+    def is_big_endian(self):
         """Pixel format is big-endian."""
-        def __get__(self): return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_BE)
+        return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_BE)
 
-    property has_palette:
+
+    @property
+    def has_palette(self):
         """Pixel format has a palette in data[1], values are indexes in this palette."""
-        def __get__(self): return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_PAL)
+        return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_PAL)
 
-    property is_bit_stream:
+
+    @property
+    def is_bit_stream(self):
         """All values of a component are bit-wise packed end to end."""
-        def __get__(self): return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_BITSTREAM)
+        return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_BITSTREAM)
+
 
     # Skipping PIX_FMT_HWACCEL
     # """Pixel format is an HW accelerated format."""
 
-    property is_planar:
+    @property
+    def is_planar(self):
         """At least one pixel component is not in the first data plane."""
-        def __get__(self): return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_PLANAR)
+        return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_PLANAR)
 
-    property is_rgb:
+
+    @property
+    def is_rgb(self):
         """The pixel format contains RGB-like data (as opposed to YUV/grayscale)."""
-        def __get__(self): return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_RGB)
+        return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_RGB)
+
 
     cpdef chroma_width(self, int luma_width=0):
         """chroma_width(luma_width=0)
@@ -124,53 +135,53 @@ cdef class VideoFormatComponent:
         self.index = index
         self.ptr = &format.ptr.comp[index]
 
-    property plane:
+    @property
+    def plane(self):
         """The index of the plane which contains this component."""
-        def __get__(self):
-            return self.ptr.plane
+        return self.ptr.plane
 
-    property bits:
+    @property
+    def bits(self):
         """Number of bits in the component."""
-        def __get__(self):
-            return self.ptr.depth
+        return self.ptr.depth
 
-    property is_alpha:
+    @property
+    def is_alpha(self):
         """Is this component an alpha channel?"""
-        def __get__(self):
-            return ((self.index == 1 and self.format.ptr.nb_components == 2) or
-                    (self.index == 3 and self.format.ptr.nb_components == 4))
+        return ((self.index == 1 and self.format.ptr.nb_components == 2) or
+                (self.index == 3 and self.format.ptr.nb_components == 4))
 
-    property is_luma:
+    @property
+    def is_luma(self):
         """Is this compoment a luma channel?"""
-        def __get__(self):
-            return self.index == 0 and (
-                self.format.ptr.nb_components == 1 or
-                self.format.ptr.nb_components == 2 or
-                not self.format.is_rgb
-            )
+        return self.index == 0 and (
+            self.format.ptr.nb_components == 1 or
+            self.format.ptr.nb_components == 2 or
+            not self.format.is_rgb
+        )
 
-    property is_chroma:
+    @property
+    def is_chroma(self):
         """Is this component a chroma channel?"""
-        def __get__(self):
-            return (self.index == 1 or self.index == 2) and (self.format.ptr.log2_chroma_w or self.format.ptr.log2_chroma_h)
+        return (self.index == 1 or self.index == 2) and (self.format.ptr.log2_chroma_w or self.format.ptr.log2_chroma_h)
 
-    property width:
+    @property
+    def width(self):
         """The width of this component's plane.
 
         Requires the parent :class:`VideoFormat` to have a width.
 
         """
-        def __get__(self):
-            return self.format.chroma_width() if self.is_chroma else self.format.width
+        return self.format.chroma_width() if self.is_chroma else self.format.width
 
-    property height:
+    @property
+    def height(self):
         """The height of this component's plane.
 
         Requires the parent :class:`VideoFormat` to have a height.
 
         """
-        def __get__(self):
-            return self.format.chroma_height() if self.is_chroma else self.format.height
+        return self.format.chroma_height() if self.is_chroma else self.format.height
 
 
 names = set()

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -158,29 +158,37 @@ cdef class VideoFrame(Frame):
             plane_count += 1
         return tuple([VideoPlane(self, i) for i in range(plane_count)])
 
-    property width:
+    @property
+    def width(self):
         """Width of the image, in pixels."""
-        def __get__(self): return self.ptr.width
+        return self.ptr.width
 
-    property height:
+
+    @property
+    def height(self):
         """Height of the image, in pixels."""
-        def __get__(self): return self.ptr.height
+        return self.ptr.height
 
-    property key_frame:
+
+    @property
+    def key_frame(self):
         """Is this frame a key frame?
 
         Wraps :ffmpeg:`AVFrame.key_frame`.
 
         """
-        def __get__(self): return self.ptr.key_frame
+        return self.ptr.key_frame
 
-    property interlaced_frame:
+
+    @property
+    def interlaced_frame(self):
         """Is this frame an interlaced or progressive?
 
         Wraps :ffmpeg:`AVFrame.interlaced_frame`.
 
         """
-        def __get__(self): return self.ptr.interlaced_frame
+        return self.ptr.interlaced_frame
+
 
     @property
     def pict_type(self):

--- a/av/video/plane.pyx
+++ b/av/video/plane.pyx
@@ -27,14 +27,14 @@ cdef class VideoPlane(Plane):
     cdef size_t _buffer_size(self):
         return self.buffer_size
 
-    property line_size:
+    @property
+    def line_size(self):
         """
         Bytes per horizontal line in this plane.
 
         :type: int
         """
-        def __get__(self):
-            return self.frame.ptr.linesize[self.index]
+        return self.frame.ptr.linesize[self.index]
 
 
 cdef class YUVPlanes(VideoPlane):

--- a/tests/test_colorspace.py
+++ b/tests/test_colorspace.py
@@ -11,7 +11,7 @@ class TestColorSpace(TestCase):
         )
         stream = container.streams.video[0]
 
-        self.assertEqual(stream.color_range, None)
+        self.assertEqual(stream.codec_context.color_range, 2)
 
         for packet in container.demux(stream):
             for frame in packet.decode():


### PR DESCRIPTION
I had some trouble with the `color_range` property in av/video/codeccontext.pyx and tests/test_colorspace.py.

After my changes, `stream.color_range` now returns `2` instead of `None` and therefore fails the test. I have no idea which one is actually correct.

Here is some additional context which may or may not be related:
1. I get this warning when opening the file used in tests/test_colorspace.py:
`container = av.open(fate_suite("amv/MTV_high_res_320x240_sample_Penguin_Joke_MTV_from_WMV.amv"))`
`WARNING  libav.avi:test_colorspace.py:9 scale/rate is 0/0 which is invalid. (This file has been generated by broken software.)`

2. The `color_range` property in av/video/codeccontext.pyx had unusal syntax. The decorator was used, but so was `__get__` and `__set__`.

3. There are two `color_range` data fields in ffmpeg:
AVCodecContext::color_range
https://ffmpeg.org//doxygen/6.0/structAVCodecContext.html#a255bf7100a4ba6dcb6ee5d87740a4f35
AVFrame::color_range
https://ffmpeg.org//doxygen/6.0/structAVFrame.html#a853afbad220bbc58549b4860732a3aa5

I'll do more research in the next few days, unless the solution is obvious to someone already.