### PR TITLE
Partially revert #1061

### DIFF
--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -6,7 +6,7 @@ from av.enum cimport define_enum
 from av.error cimport err_check
 from av.utils cimport check_ndarray, check_ndarray_shape
 from av.video.format cimport get_pix_fmt, get_video_format
-from av.video.plane cimport VideoPlane, YUVPlanes
+from av.video.plane cimport VideoPlane
 
 import warnings
 
@@ -303,21 +303,11 @@ cdef class VideoFrame(Frame):
         if frame.format.name in ("yuv420p", "yuvj420p"):
             assert frame.width % 2 == 0
             assert frame.height % 2 == 0
-            # Fast path for the case that the entire YUV data is contiguous
-            if (
-                frame.planes[0].line_size == frame.planes[0].width and
-                frame.planes[1].line_size == frame.planes[1].width and
-                frame.planes[2].line_size == frame.planes[2].width
-            ):
-                yuv_planes = YUVPlanes(frame, 0)
-                return useful_array(yuv_planes).reshape(frame.height * 3 // 2, frame.width)
-            else:
-                # Otherwise, we need to copy the data through the use of np.hstack
-                return np.hstack((
-                    useful_array(frame.planes[0]),
-                    useful_array(frame.planes[1]),
-                    useful_array(frame.planes[2])
-                )).reshape(-1, frame.width)
+            return np.hstack((
+                useful_array(frame.planes[0]),
+                useful_array(frame.planes[1]),
+                useful_array(frame.planes[2])
+            )).reshape(-1, frame.width)
         elif frame.format.name in ("yuv444p", "yuvj444p"):
             return np.hstack((
                 useful_array(frame.planes[0]),

--- a/av/video/plane.pxd
+++ b/av/video/plane.pxd
@@ -6,7 +6,3 @@ cdef class VideoPlane(Plane):
 
     cdef readonly size_t buffer_size
     cdef readonly unsigned int width, height
-
-
-cdef class YUVPlanes(VideoPlane):
-    pass

--- a/av/video/plane.pyx
+++ b/av/video/plane.pyx
@@ -35,20 +35,3 @@ cdef class VideoPlane(Plane):
         :type: int
         """
         return self.frame.ptr.linesize[self.index]
-
-
-cdef class YUVPlanes(VideoPlane):
-    def __cinit__(self, VideoFrame frame, int index):
-        if index != 0:
-            raise RuntimeError("YUVPlanes only supports index 0")
-        if frame.format.name not in ("yuvj420p", "yuv420p"):
-            raise RuntimeError("YUVPlane only supports yuv420p and yuvj420p")
-        if frame.ptr.linesize[0] < 0:
-            raise RuntimeError("YUVPlane only supports positive linesize")
-        self.width = frame.width
-        self.height = frame.height * 3 // 2
-        self.buffer_size = self.height *  abs(self.frame.ptr.linesize[0])
-        self.frame = frame
-
-    cdef void* _buffer_ptr(self):
-        return self.frame.ptr.extended_data[self.index]


### PR DESCRIPTION
The YUV fastpath did not preserve the underlying byte-order, which causes issues for applications that rely on it.