### PR TITLE
Fix wheels not published to pypi on release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,7 +242,7 @@ jobs:
           name: dist
           path: dist/
       - name: Publish to PyPI
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+        if: github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
The latest 12.0.0 release did not get publish to PyPI successfully, as it was triggered by release instead of tag push. This PR should fix this problem.

btw You might have to manually upload wheels for this release, or recreate release for 12.0.0 wheels to be published...