### PR TITLE
Trigger workflow on release publish

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: tests
 on:
   release:
-    types: [created]
+    types: [published]
   push:
     branches: main
     paths-ignore:


### PR DESCRIPTION
Continuation of https://github.com/PyAV-Org/PyAV/pull/1341

Wheels did not get push to PyPI again... Should had also change trigger to release published.