### PR TITLE
Bitstream filter API fixes

### DIFF
--- a/av/bitstream.pxd
+++ b/av/bitstream.pxd
@@ -8,3 +8,4 @@ cdef class BitStreamFilterContext:
     cdef const lib.AVBSFContext *ptr
 
     cpdef filter(self, Packet packet=?)
+    cpdef flush(self)

--- a/av/bitstream.pyi
+++ b/av/bitstream.pyi
@@ -3,8 +3,12 @@ from .stream import Stream
 
 class BitStreamFilterContext:
     def __init__(
-        self, filter_description: str | bytes, stream: Stream | None = None
+        self,
+        filter_description: str | bytes,
+        in_stream: Stream | None = None,
+        out_stream: Stream | None = None,
     ): ...
     def filter(self, packet: Packet | None) -> list[Packet]: ...
+    def flush(self) -> None: ...
 
 bitstream_filters_available: set[str]

--- a/include/libavcodec/bsf.pxd
+++ b/include/libavcodec/bsf.pxd
@@ -34,3 +34,7 @@ cdef extern from "libavcodec/bsf.h" nogil:
         AVBSFContext *ctx,
         AVPacket *pkt
     )
+
+    cdef void av_bsf_flush(
+        AVBSFContext *ctx
+    )

--- a/tests/test_bitstream.py
+++ b/tests/test_bitstream.py
@@ -71,7 +71,7 @@ class TestBitStreamFilters(TestCase):
             self.assertFalse(is_annexb(stream.codec_context.extradata))
             del ctx
 
-            ctx = BitStreamFilterContext("h264_mp4toannexb", stream, out_stream=stream)
+            _ = BitStreamFilterContext("h264_mp4toannexb", stream, out_stream=stream)
             self.assertTrue(is_annexb(stream.codec_context.extradata))
 
     def test_filter_flush(self) -> None:

--- a/tests/test_bitstream.py
+++ b/tests/test_bitstream.py
@@ -5,6 +5,11 @@ from av.bitstream import BitStreamFilterContext, bitstream_filters_available
 from .common import TestCase, fate_suite
 
 
+def is_annexb(packet: Packet) -> bool:
+    data = bytes(packet)
+    return data[:3] == b"\0\0\x01" or data[:4] == b"\0\0\0\x01"
+
+
 class TestBitStreamFilters(TestCase):
     def test_filters_availible(self) -> None:
         self.assertIn("h264_mp4toannexb", bitstream_filters_available)
@@ -43,10 +48,6 @@ class TestBitStreamFilters(TestCase):
         self.assertEqual(result_packets[1].pts, 1)
 
     def test_filter_h264_mp4toannexb(self) -> None:
-        def is_annexb(packet: Packet) -> bool:
-            data = bytes(packet)
-            return data[:3] == b"\0\0\x01" or data[:4] == b"\0\0\0\x01"
-
         with av.open(fate_suite("h264/interlaced_crop.mp4"), "r") as container:
             stream = container.streams.video[0]
             ctx = BitStreamFilterContext("h264_mp4toannexb", stream)
@@ -60,3 +61,38 @@ class TestBitStreamFilters(TestCase):
 
             for p in res_packets:
                 self.assertTrue(is_annexb(p))
+
+    def test_filter_output_parameters(self) -> None:
+        with av.open(fate_suite("h264/interlaced_crop.mp4"), "r") as container:
+            stream = container.streams.video[0]
+
+            self.assertFalse(is_annexb(stream.codec_context.extradata))
+            ctx = BitStreamFilterContext("h264_mp4toannexb", stream)
+            self.assertFalse(is_annexb(stream.codec_context.extradata))
+            del ctx
+
+            ctx = BitStreamFilterContext("h264_mp4toannexb", stream, out_stream=stream)
+            self.assertTrue(is_annexb(stream.codec_context.extradata))
+
+    def test_filter_flush(self) -> None:
+        with av.open(fate_suite("h264/interlaced_crop.mp4"), "r") as container:
+            stream = container.streams.video[0]
+            ctx = BitStreamFilterContext("h264_mp4toannexb", stream)
+
+            res_packets = []
+            for p in container.demux(stream):
+                res_packets.extend(ctx.filter(p))
+            self.assertEqual(len(res_packets), stream.frames)
+
+            container.seek(0)
+            # Without flushing, we expect to get an error: "A non-NULL packet sent after an EOF."
+            with self.assertRaises(ValueError):
+                for p in container.demux(stream):
+                    ctx.filter(p)
+
+            ctx.flush()
+            container.seek(0)
+            for p in container.demux(stream):
+                res_packets.extend(ctx.filter(p))
+
+            self.assertEqual(len(res_packets), stream.frames * 2)


### PR DESCRIPTION
Hello again,

This is a little follow-up to PR #1375 and issue #489
I realized and fixed 2 problems with the API as defined previously:

* `par_out` of AVBSFContext stands for output parameters and it contains the codec parameters as modified by the bitfilter. This needs to be exposed so that the user can get the modified codec.

Here's a minimal example that shows example expected usage and why it's useful to separate the input and output arguments:

```
with av.open(input_path, mode='r') as input_av_container:
    v_stream = input_av_container.streams.video[0]

    with av.open(output_path, 'w') as output_av_container:
        out_stream = output_av_container.add_stream(template=v_stream)

        filter = av.bitstream.BitStreamFilterContext('h264_mp4toannexb',
            in_stream = v_stream, out_stream = out_stream)

        for packet in input_av_container.demux(v_stream):
            for p in filter.filter(packet):
                p.stream = out_stream
                output_av_container.mux(p)

        for p in filter.filter(None):
            p.stream = out_stream
            output_av_container.mux(p)
```

* `av_bsf_flush` is useful during discontinuous demuxing, e.g. after seeking. It allows reset of the internal bitfilter state. Otherwise you'd have to destroy and recreate the filter every time after seeking/draining the internal filter buffer. This is now exposed as `BitStreamFilterContext.flush()`. I also added a test case for this function.