### PR TITLE
Expose CodecContext flush_buffers

### DIFF
--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -37,6 +37,8 @@ cdef class CodecContext:
     cpdef encode(self, Frame frame=?)
     cpdef decode(self, Packet packet=?)
 
+    cpdef flush_buffers(self)
+
     # Used by both transcode APIs to setup user-land objects.
     # TODO: Remove the `Packet` from `_setup_decoded_frame` (because flushing
     # packets are bogus). It should take all info it needs from the context and/or stream.

--- a/av/codec/context.pyi
+++ b/av/codec/context.pyi
@@ -1,6 +1,7 @@
 from typing import Any, Literal
 
 from av.enum import EnumFlag, EnumItem
+from av.frame import Frame
 from av.packet import Packet
 
 from .codec import Codec
@@ -78,3 +79,6 @@ class CodecContext:
     def parse(
         self, raw_input: bytes | bytearray | memoryview | None = None
     ) -> list[Packet]: ...
+    def encode(self, frame: Frame | None) -> list[Packet]: ...
+    def decode(self, packet: Packet | None) -> list[Frame]: ...
+    def flush_buffers(self) -> None: ...

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -510,6 +510,17 @@ cdef class CodecContext:
             res.append(frame)
         return res
 
+    cpdef flush_buffers(self):
+        """Reset the internal codec state and discard all internal buffers.
+
+        Should be called before you start decoding from a new position e.g.
+        when seeking or when switching to a different stream.
+
+        """
+        if self.is_open:
+            with nogil:
+                lib.avcodec_flush_buffers(self.ptr)
+
     cdef _setup_decoded_frame(self, Frame frame, Packet packet):
 
         # Propagate our manual times.

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -278,6 +278,5 @@ cdef class InputContainer(Container):
 
         for stream in self.streams:
             codec_context = stream.codec_context
-            if codec_context and codec_context.is_open:
-                with nogil:
-                    lib.avcodec_flush_buffers(codec_context.ptr)
+            if codec_context:
+                codec_context.flush_buffers()


### PR DESCRIPTION
expose `avcodec_flush_buffers()`

From ffmpeg documentation (https://ffmpeg.org/doxygen/trunk/group__lavc__misc.html#gaf60b0e076f822abcb2700eb601d352a6)

```
void avcodec_flush_buffers	(	AVCodecContext * 	avctx	)	
Reset the internal codec state / flush internal buffers.

Should be called e.g. when seeking or when switching to a different stream.
```

Currently with PyAV the only way to reset the CodecContext state is to call seek on the container. This has the downside that it resets the codecs for ALL the streams. This can be annoying if you are doing more advanced stuff like switching between streams midway but don't want to call seek, selectively decode only some streams based on logic, or have the decoding heads at different points in time for different streams and need to sync them up, etc. Exposing `avcodec_flush_buffers` makes it much easier to decode in whatever order you want or even in different orders in different streams.

I also added type hints for `encode` and `decode` since those are missing from `codec/context.pyi`.