### PR TITLE
Update GitHub actions to their latest version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-14
             arch: arm64
           - os: macos-13
             arch: x86_64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ jobs:
           python scripts/fetch-vendor.py --config-file scripts/ffmpeg-6.1.json /tmp/vendor
           PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig python setup.py sdist
       - name: Upload source package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-source
           path: dist/
 
   package-wheel:
@@ -73,9 +73,9 @@ jobs:
           cibuildwheel --output-dir dist
         shell: bash
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/
 
   publish:
@@ -83,9 +83,9 @@ jobs:
     needs: [package-source, package-wheel]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: dist
+          merge-multiple: true
           path: dist/
       - name: Publish to PyPI
         if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
The behaviour of `actions/upload-artifact` have changed, we now need distinct names for each artifact. This also means adjusting our use of `actions/download-artifact` to collect all artifacts.