### PR TITLE
Update binary FFmpeg build

### DIFF
--- a/scripts/ffmpeg-6.1.json
+++ b/scripts/ffmpeg-6.1.json
@@ -1,3 +1,3 @@
 {
-    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/6.1.1-1/ffmpeg-{platform}.tar.gz"]
+    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/6.1.1-3/ffmpeg-{platform}.tar.gz"]
 }


### PR DESCRIPTION
This adds support for `webp` and removes X11 libraries which were dragged into the macOs builds.