### PR TITLE
Restore tests against FFmpeg 5.x

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,6 +39,8 @@ jobs:
         config:
           - {os: ubuntu-latest, python: "3.8", ffmpeg: "6.1", extras: true}
           - {os: ubuntu-latest, python: "3.8", ffmpeg: "6.0"}
+          - {os: ubuntu-latest, python: "3.8", ffmpeg: "5.1"}
+          - {os: ubuntu-latest, python: "3.8", ffmpeg: "5.0"}
           - {os: ubuntu-latest, python: pypy3.9, ffmpeg: "6.1"}
           - {os: macos-12,  python: "3.8", ffmpeg: "6.1"}
 
@@ -118,6 +120,8 @@ jobs:
         config:
           - {os: windows-latest, python: "3.8", ffmpeg: "6.1"}
           - {os: windows-latest, python: "3.8", ffmpeg: "6.0"}
+          - {os: windows-latest, python: "3.8", ffmpeg: "5.1"}
+          - {os: windows-latest, python: "3.8", ffmpeg: "5.0"}
 
     steps:
     - name: Checkout

--- a/docs/overview/installation.rst
+++ b/docs/overview/installation.rst
@@ -55,7 +55,7 @@ See the `Conda quick install <https://conda.io/docs/install/quick.html>`_ docs t
 Bring your own FFmpeg
 ---------------------
 
-PyAV can also be compiled against your own build of FFmpeg ((version ``6.0`` or higher). You can force installing PyAV from source by running:
+PyAV can also be compiled against your own build of FFmpeg ((version ``5.0`` or higher). You can force installing PyAV from source by running:
 
 .. code-block:: bash
 

--- a/scripts/ffmpeg-5.0.json
+++ b/scripts/ffmpeg-5.0.json
@@ -1,0 +1,3 @@
+{
+    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.0.1-1/ffmpeg-{platform}.tar.gz"]
+}

--- a/scripts/ffmpeg-5.1.json
+++ b/scripts/ffmpeg-5.1.json
@@ -1,0 +1,3 @@
+{
+    "urls": ["https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/5.1.3-1/ffmpeg-{platform}.tar.gz"]
+}


### PR DESCRIPTION
This reverts e884e6cd1dac2646fd002b441ca4fdfb2ef818c5.

So far we have not made any changes which justify dropping FFmpeg 5.x, and we do not change the supported platforms in a minor release. We will drop compatibility for FFmpeg 5.x once we switch to the new audio channel API.