### PR TITLE
fix: use `av_guess_sample_aspect_ratio` when reporting stream SAR

### DIFF
--- a/av/video/stream.pyi
+++ b/av/video/stream.pyi
@@ -14,6 +14,8 @@ class VideoStream(Stream):
     bit_rate_tolerance: int
     thread_count: int
     thread_type: Any
+    sample_aspect_ratio: Fraction | None
+    display_aspect_ratio: Fraction | None
     codec_context: VideoCodecContext
     # from codec context
     format: VideoFormat
@@ -24,8 +26,6 @@ class VideoStream(Stream):
     framerate: Fraction
     rate: Fraction
     gop_size: int
-    sample_aspect_ratio: Fraction | None
-    display_aspect_ratio: Fraction | None
     has_b_frames: bool
     coded_width: int
     coded_height: int

--- a/av/video/stream.pyx
+++ b/av/video/stream.pyx
@@ -111,7 +111,7 @@ cdef class VideoStream(Stream):
 
         lib.av_reduce(
             &dar.num, &dar.den,
-            self.format.width * self.ptr.sample_aspect_ratio.num,
-            self.format.height * self.ptr.sample_aspect_ratio.den, 1024*1024)
+            self.format.width * self.sample_aspect_ratio.num,
+            self.format.height * self.sample_aspect_ratio.den, 1024*1024)
 
         return avrational_to_fraction(&dar)

--- a/include/libavformat/avformat.pxd
+++ b/include/libavformat/avformat.pxd
@@ -325,6 +325,12 @@ cdef extern from "libavformat/avformat.h" nogil:
         AVFrame *frame
     )
 
+    cdef AVRational av_guess_sample_aspect_ratio(
+        AVFormatContext *ctx,
+        AVStream *stream,
+        AVFrame *frame
+    )
+
     cdef const AVInputFormat* av_demuxer_iterate(void **opaque)
     cdef const AVOutputFormat* av_muxer_iterate(void **opaque)
 


### PR DESCRIPTION
When user requests stream's SAR, use the upstream's heuristic function ([`av_guess_sample_aspect_ratio()`](https://github.com/FFmpeg/FFmpeg/commit/9163faecd3cdd93b69ae98605e7f518bd228196e)) to report it.


Resolves: https://github.com/PyAV-Org/PyAV/issues/1267