### PR TITLE
Fix `AudioLayout`'s "copy" constructor (fixes: #1434)

### DIFF
--- a/av/audio/layout.pyx
+++ b/av/audio/layout.pyx
@@ -76,7 +76,7 @@ cdef class AudioLayout:
         elif isinstance(layout, str):
             c_layout = lib.av_get_channel_layout(layout)
         elif isinstance(layout, AudioLayout):
-            c_layout = layout.layout
+            c_layout = (<AudioLayout>layout).layout
         else:
             raise TypeError("layout must be str or int")
 

--- a/tests/test_audiolayout.py
+++ b/tests/test_audiolayout.py
@@ -4,13 +4,18 @@ from .common import TestCase
 
 
 class TestAudioLayout(TestCase):
-    def test_stereo_properties(self):
+    def test_stereo_from_str(self):
         layout = AudioLayout("stereo")
         self._test_stereo(layout)
 
-    def test_2channel_properties(self) -> None:
+    def test_stereo_from_int(self):
         layout = AudioLayout(2)
         self._test_stereo(layout)
+
+    def test_stereo_from_layout(self):
+        layout = AudioLayout("stereo")
+        layout2 = AudioLayout(layout)
+        self._test_stereo(layout2)
 
     def test_channel_counts(self):
         self.assertRaises(ValueError, AudioLayout, -1)

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -4,7 +4,7 @@ from fractions import Fraction
 from unittest import SkipTest
 
 import av
-from av import AudioResampler, Codec, Packet
+from av import AudioLayout, AudioResampler, Codec, Packet
 from av.codec.codec import UnknownCodecError
 from av.video.frame import PictureType
 
@@ -393,6 +393,12 @@ class TestEncoding(TestCase):
     maxDiff = None
 
     def audio_encoding(self, codec_name):
+        self._audio_encoding(codec_name=codec_name, channel_layout="stereo")
+        self._audio_encoding(
+            codec_name=codec_name, channel_layout=AudioLayout("stereo")
+        )
+
+    def _audio_encoding(self, *, codec_name, channel_layout):
         try:
             codec = Codec(codec_name, "w")
         except UnknownCodecError:
@@ -404,14 +410,12 @@ class TestEncoding(TestCase):
 
         sample_fmt = ctx.codec.audio_formats[-1].name
         sample_rate = 48000
-        channel_layout = "stereo"
         channels = 2
 
         ctx.time_base = Fraction(1) / sample_rate
         ctx.sample_rate = sample_rate
         ctx.format = sample_fmt
         ctx.layout = channel_layout
-        ctx.channels = channels
 
         ctx.open()
 
@@ -549,7 +553,6 @@ class TestEncoding(TestCase):
         ctx.sample_rate = sample_rate
         ctx.format = sample_fmt
         ctx.layout = channel_layout
-        ctx.channels = channels
         ctx.open()
 
         result_samples = 0


### PR DESCRIPTION
There are several places where `AudioLayout` instances can be created from another instance, for example the `AudioCodecContext.layout` setter, but this variant of the constructor is broken.