### PR TITLE
Add type definitions for `CodecContext` properties

### DIFF
--- a/av/codec/context.pyi
+++ b/av/codec/context.pyi
@@ -1,7 +1,7 @@
+from fractions import Fraction
 from typing import Any, Literal
 
 from av.enum import EnumFlag, EnumItem
-from av.frame import Frame
 from av.packet import Packet
 
 from .codec import Codec
@@ -60,8 +60,10 @@ class CodecContext:
     is_encoder: bool
     is_decoder: bool
     name: str
+    options: dict[str, str]
     type: Literal["video", "audio", "data", "subtitle", "attachment"]
     profile: str | None
+    time_base: Fraction
     codec_tag: str
     bit_rate: int | None
     max_bit_rate: int | None


### PR DESCRIPTION
Add type definitions for `options` and `time_base`.