### PR TITLE
Include libav headers in final distribution

### DIFF
--- a/av/__init__.py
+++ b/av/__init__.py
@@ -48,8 +48,8 @@ def get_include() -> str:
     Returns the path to the `include` folder to be used when building extensions to av.
     """
     # Installed package
-    include_path = os.path.join(os.path.dirname(__file__), 'include')
+    include_path = os.path.join(os.path.dirname(__file__), "include")
     if os.path.exists(include_path):
         return include_path
     # Running from source directory
-    return os.path.join(os.path.dirname(__file__), os.pardir, 'include')
+    return os.path.join(os.path.dirname(__file__), os.pardir, "include")

--- a/av/__init__.py
+++ b/av/__init__.py
@@ -41,3 +41,15 @@ from av.video.frame import VideoFrame
 
 # Backwards compatibility
 AVError = FFmpegError  # noqa: F405
+
+
+def get_include() -> str:
+    """
+    Returns the path to the `include` folder to be used when building extensions to av.
+    """
+    # Installed package
+    include_path = os.path.join(os.path.dirname(__file__), 'include')
+    if os.path.exists(include_path):
+        return include_path
+    # Running from source directory
+    return os.path.join(os.path.dirname(__file__), os.pardir, 'include')

--- a/av/utils.pyx
+++ b/av/utils.pyx
@@ -92,18 +92,6 @@ cdef flag_in_bitfield(uint64_t bitfield, uint64_t flag):
     return bool(bitfield & flag)
 
 
-def get_include() -> str:
-    """
-    Returns the path to the `include` folder to be used when building extensions to av.
-    """
-    # Installed package
-    include_path = os.path.join(os.path.dirname(__file__), 'include')
-    if os.path.exists(include_path):
-        return include_path
-    # Running from source directory
-    return os.path.join(os.path.dirname(__file__), os.pardir, 'include')
-
-
 # === BACKWARDS COMPAT ===
 
 from .error import FFmpegError as AVError

--- a/av/utils.pyx
+++ b/av/utils.pyx
@@ -1,5 +1,6 @@
 from libc.stdint cimport uint64_t
 
+import os
 from fractions import Fraction
 
 cimport libav as lib
@@ -89,6 +90,18 @@ cdef flag_in_bitfield(uint64_t bitfield, uint64_t flag):
     if not flag:
         return None
     return bool(bitfield & flag)
+
+
+def get_include() -> str:
+    """
+    Returns the path to the `include` folder to be used when building extensions to av.
+    """
+    # Installed package
+    include_path = os.path.join(os.path.dirname(__file__), 'include')
+    if os.path.exists(include_path):
+        return include_path
+    # Running from source directory
+    return os.path.join(os.path.dirname(__file__), os.pardir, 'include')
 
 
 # === BACKWARDS COMPAT ===

--- a/av/utils.pyx
+++ b/av/utils.pyx
@@ -1,6 +1,5 @@
 from libc.stdint cimport uint64_t
 
-import os
 from fractions import Fraction
 
 cimport libav as lib

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,10 @@ package_data = {
     ".".join(pckg.parts): ["*.pxd", "*.pyi", "*.typed"] for pckg in package_folders
 }
 
+# Add include/ headers to av.include
+package_dir = {".".join(["av", *pckg.parts]): str(pckg) for pckg in pathlib.Path("include").glob("**/")}
+package_data.update({pckg: ["*.pxd"] for pckg in package_dir})
+
 
 with open("README.md") as f:
     long_description = f.read()
@@ -203,7 +207,8 @@ setup(
     author="Mike Boers",
     author_email="pyav@mikeboers.com",
     url="https://github.com/PyAV-Org/PyAV",
-    packages=find_packages(exclude=["build*", "examples*", "scratchpad*", "tests*"]),
+    packages=find_packages(exclude=["build*", "examples*", "scratchpad*", "tests*", "include*"]) + list(package_dir.keys()),
+    package_dir=package_dir,
     package_data=package_data,
     python_requires=">=3.8",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,10 @@ package_data = {
 }
 
 # Add include/ headers to av.include
-package_dir = {".".join(["av", *pckg.parts]): str(pckg) for pckg in pathlib.Path("include").glob("**/")}
+package_dir = {
+    ".".join(["av", *pckg.parts]): str(pckg)
+    for pckg in pathlib.Path("include").glob("**/")
+}
 package_data.update({pckg: ["*.pxd"] for pckg in package_dir})
 
 
@@ -207,7 +210,10 @@ setup(
     author="Mike Boers",
     author_email="pyav@mikeboers.com",
     url="https://github.com/PyAV-Org/PyAV",
-    packages=find_packages(exclude=["build*", "examples*", "scratchpad*", "tests*", "include*"]) + list(package_dir.keys()),
+    packages=find_packages(
+        exclude=["build*", "examples*", "scratchpad*", "tests*", "include*"]
+    )
+    + list(package_dir.keys()),
     package_dir=package_dir,
     package_data=package_data,
     python_requires=">=3.8",


### PR DESCRIPTION
Closes #1356, continuation of #717.

Adds the `pxd` files in `./include` to the final package distribution, under `av.include`. This allows to build cython extensions to PyAV by including the folder and calling `cimport av`.

Also added a `get_include` method to retrieve the path to the folder to add to the `include_dirs` in `setup.py`, similar to [numpy](https://numpy.org/doc/stable/reference/generated/numpy.get_include.html).
