### PR TITLE
Remove TextSubtitle, add dialogue property

### DIFF
--- a/av/subtitles/subtitle.pyi
+++ b/av/subtitles/subtitle.pyi
@@ -27,10 +27,11 @@ class BitmapSubtitlePlane:
     index: int
     buffer_size: int
 
-class TextSubtitle(Subtitle):
-    type: Literal[b"text"]
-    text: bytes
-
 class AssSubtitle(Subtitle):
-    type: Literal[b"ass"]
-    ass: bytes
+    type: Literal[b"ass", b"text"]
+    @property
+    def ass(self) -> bytes: ...
+    @property
+    def dialogue(self) -> bytes: ...
+    @property
+    def text(self) -> bytes: ...

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -5,7 +5,7 @@ from .common import TestCase, fate_suite
 
 
 class TestSubtitle(TestCase):
-    def test_movtext(self):
+    def test_movtext(self) -> None:
         path = fate_suite("sub/MovText_capability_tester.mp4")
 
         subs = []
@@ -23,8 +23,12 @@ class TestSubtitle(TestCase):
 
         sub = subset[0]
         self.assertIsInstance(sub, AssSubtitle)
+        assert isinstance(sub, AssSubtitle)
+
         self.assertEqual(sub.type, b"ass")
+        self.assertEqual(sub.text, b"")
         self.assertEqual(sub.ass, b"0,0,Default,,0,0,0,,- Test 1.\\N- Test 2.")
+        self.assertEqual(sub.dialogue, b"- Test 1.\n- Test 2.")
 
     def test_vobsub(self):
         path = fate_suite("sub/vobsub.sub")


### PR DESCRIPTION
AssSubtitle is used even for non ASS/SSA formats. These changes make that more obvious to users. FFmpeg does not export ass_split.h, so the dialogue getter is implemented directly in Cython.