### PR TITLE
fix: set default color range for VideoReformatter.format()

### DIFF
--- a/av/video/reformatter.pyx
+++ b/av/video/reformatter.pyx
@@ -110,6 +110,10 @@ cdef class VideoReformatter:
         if frame.ptr.format < 0:
             raise ValueError("Frame does not have format set.")
 
+        # The definition of color range in pixfmt.h and swscale.h is different.
+        src_color_range = 1 if src_color_range == ColorRange.JPEG.value else 0
+        dst_color_range = 1 if dst_color_range == ColorRange.JPEG.value else 0
+
         cdef lib.AVPixelFormat src_format = <lib.AVPixelFormat> frame.ptr.format
 
         # Shortcut!

--- a/av/video/reformatter.pyx
+++ b/av/video/reformatter.pyx
@@ -76,9 +76,9 @@ cdef class VideoReformatter:
         :type  dst_colorspace: :class:`Colorspace` or ``str``
         :param interpolation: The interpolation method to use, or ``None`` for ``BILINEAR``.
         :type  interpolation: :class:`Interpolation` or ``str``
-        :param src_color_range: Current color range, or ``None`` for the frame color range.
+        :param src_color_range: Current color range, or ``None`` for the ``UNSPECIFIED``.
         :type  src_color_range: :class:`color range` or ``str``
-        :param dst_color_range: Desired color range, or ``None`` for the frame color range.
+        :param dst_color_range: Desired color range, or ``None`` for the ``UNSPECIFIED``.
         :type  dst_color_range: :class:`color range` or ``str``
 
         """


### PR DESCRIPTION
The behavior of the VideoReformatter.format() is inconsistent with the documentation. According to the documentation, when color_range is None, it should use the color_range of the frame. However, in the function implementation, the default is set to 0.