### PR TITLE
flushing subtitle decoder requires a new uninitialized packet

### DIFF
--- a/av/subtitles/stream.pxd
+++ b/av/subtitles/stream.pxd
@@ -1,5 +1,6 @@
+from av.packet cimport Packet
 from av.stream cimport Stream
 
 
 cdef class SubtitleStream(Stream):
-    pass
+    cpdef decode(self, Packet packet=?)

--- a/av/subtitles/stream.pyi
+++ b/av/subtitles/stream.pyi
@@ -1,3 +1,6 @@
+from av.packet import Packet
 from av.stream import Stream
+from av.subtitles.subtitle import SubtitleSet
 
-class SubtitleStream(Stream): ...
+class SubtitleStream(Stream):
+    def decode(self, packet: Packet | None = None) -> list[SubtitleSet]: ...

--- a/av/subtitles/stream.pyx
+++ b/av/subtitles/stream.pyx
@@ -1,6 +1,23 @@
+from av.packet cimport Packet
+from av.stream cimport Stream
+
+
 cdef class SubtitleStream(Stream):
     """
     A :class:`SubtitleStream` can contain many :class:`SubtitleSet` objects accessible via decoding.
     """
     def __getattr__(self, name):
         return getattr(self.codec_context, name)
+
+    cpdef decode(self, Packet packet=None):
+        """
+        Decode a :class:`.Packet` and return a list of :class:`.SubtitleSet`.
+
+        :rtype: list[SubtitleSet]
+
+        .. seealso:: This is a passthrough to :meth:`.CodecContext.decode`.
+        """
+        if not packet:
+            packet = Packet()
+
+        return self.codec_context.decode(packet)

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -58,3 +58,15 @@ class TestSubtitle(TestCase):
         bms = sub.planes
         self.assertEqual(len(bms), 1)
         self.assertEqual(len(memoryview(bms[0])), 4800)
+
+    def test_subtitle_flush(self) -> None:
+        path = fate_suite("sub/MovText_capability_tester.mp4")
+
+        subs = []
+        with av.open(path) as container:
+            stream = container.streams.subtitles[0]
+            for packet in container.demux(stream):
+                subs.extend(stream.decode(packet))
+                subs.extend(stream.decode())
+
+        self.assertEqual(len(subs), 3)


### PR DESCRIPTION
Implement proper flushing mechanism when using `avcodec_decode_subtitle2`.


Closes: #1454