### PR TITLE
Add support for creating `VideoFrame` directly from bytes (`from_bytes`)

### DIFF
--- a/av/video/frame.pyi
+++ b/av/video/frame.pyi
@@ -63,3 +63,12 @@ class VideoFrame(Frame):
     ) -> VideoFrame: ...
     @staticmethod
     def from_ndarray(array: _SupportedNDarray, format: str = "rgb24") -> VideoFrame: ...
+    @staticmethod
+    def from_bytes(
+        data: bytes,
+        width: int,
+        height: int,
+        format="rgba",
+        flip_horizontal=False,
+        flip_vertical=False,
+    ) -> VideoFrame: ...


### PR DESCRIPTION
This pull request introduces a new feature to the `VideoFrame` class, allowing the creation of a `VideoFrame` object directly from byte data. With the new `from_bytes` method, it's possible to build a frame without the need for an intermediate converter like `PIL` or `NumPy`.

### Key changes:

- Added `from_bytes` method: Allows creating a `VideoFrame` from bytes, specifying width, height, image format, and options for horizontal and vertical flipping.
- Refactored `copy_array_to_plane` function: Updated to call a new helper function, `copy_bytes_to_plane`, which handles byte copying with support for flipping.

These changes remove the need for intermediate converters, such as `PIL` or `NumPy`, streamlining the process of creating video frames directly from bytes. The implementation supports the `"rgba"` format and raises an exception for unsupported formats.

### Performance Comparison:

Here are the results of the performance tests for different implementations (using a `1280x720px` buffer in rgba format, unsigned byte):

#### Implementation 1: Using PIL to create an image and then converting it to a VideoFrame:

```python
from PIL import Image
import time

start_time = time.time()

img = Image.frombytes("RGBA", (width, height), buffer).transpose(Image.FLIP_TOP_BOTTOM)
frame = av.VideoFrame.from_image(img)

end_time = time.time()
print(f"Implementation 1 - Took ~ {end_time - start_time}")

```

**_Implementation 1 - Took ~ 0.0301 seconds._**

#### Implementation 2: Directly creating a VideoFrame from bytes, with support for flipping:

```python

start_time = time.time()
import time

frame = av.VideoFrame.from_bytes(buffer, width, height, flip_horizontal=False, flip_vertical=True)

end_time = time.time()
print(f"Implementation 2 - Took ~ {end_time - start_time}")
```
_**Implementation 2 - Took ~ 0.0023 seconds.**_

That is a performance improvement of around **13x**! 