### PR TITLE
feat: expose opaque and opaque_ref

### DIFF
--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -69,6 +69,14 @@ Flags = define_enum("Flags", __name__, (
     ("DROPCHANGED", 1 << 5,
         "Don't output frames whose parameters differ from first decoded frame in stream."
     ),
+    ("RECON_FRAME", lib.AV_CODEC_FLAG_RECON_FRAME, "Request the encoder to output reconstructed frames, i.e. frames that would be produced by decoding the encoded bistream."),
+    ("COPY_OPAQUE", lib.AV_CODEC_FLAG_COPY_OPAQUE,
+        """Request the decoder to propagate each packet's AVPacket.opaque and AVPacket.opaque_ref
+        to its corresponding output AVFrame. Request the encoder to propagate each frame's
+        AVFrame.opaque and AVFrame.opaque_ref values to its corresponding output AVPacket."""),
+    ("FRAME_DURATION", lib.AV_CODEC_FLAG_FRAME_DURATION,
+        """Signal to the encoder that the values of AVFrame.duration are valid and should be
+        used (typically for transferring them to output packets)."""),
     ("PASS1", lib.AV_CODEC_FLAG_PASS1, "Use internal 2pass ratecontrol in first pass mode."),
     ("PASS2", lib.AV_CODEC_FLAG_PASS2, "Use internal 2pass ratecontrol in second pass mode."),
     ("LOOP_FILTER", lib.AV_CODEC_FLAG_LOOP_FILTER, "loop filter."),
@@ -150,6 +158,9 @@ cdef class CodecContext:
     output_corrupt = flags.flag_property("OUTPUT_CORRUPT")
     qpel = flags.flag_property("QPEL")
     drop_changed = flags.flag_property("DROPCHANGED")
+    recon_frame = flags.flag_property("RECON_FRAME")
+    copy_opaque = flags.flag_property("COPY_OPAQUE")
+    frame_duration = flags.flag_property("FRAME_DURATION")
     pass1 = flags.flag_property("PASS1")
     pass2 = flags.flag_property("PASS2")
     loop_filter = flags.flag_property("LOOP_FILTER")

--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -1,4 +1,5 @@
 from av.error cimport err_check
+from av.opaque cimport opaque_container
 from av.utils cimport avrational_to_fraction, to_avrational
 
 from av.sidedata.sidedata import SideDataContainer
@@ -146,3 +147,16 @@ cdef class Frame:
 
         ret = lib.av_frame_make_writable(self.ptr)
         err_check(ret)
+
+    @property
+    def opaque(self):
+        if self.ptr.opaque_ref is not NULL:
+            return opaque_container.get(<char *> self.ptr.opaque_ref.data)
+
+    @opaque.setter
+    def opaque(self, v):
+        lib.av_buffer_unref(&self.ptr.opaque_ref)
+
+        if v is None:
+            return
+        self.ptr.opaque_ref = opaque_container.add(v)

--- a/av/opaque.pxd
+++ b/av/opaque.pxd
@@ -1,0 +1,12 @@
+cimport libav as lib
+
+
+cdef class OpaqueContainer:
+    cdef dict _by_name
+
+    cdef lib.AVBufferRef *add(self, object v)
+    cdef object get(self, bytes name)
+    cdef object pop(self, bytes name)
+
+
+cdef OpaqueContainer opaque_container

--- a/av/opaque.pyx
+++ b/av/opaque.pyx
@@ -1,0 +1,32 @@
+cimport libav as lib
+from libc.stdint cimport uint8_t
+
+from uuid import uuid4
+
+
+cdef void key_free(void *opaque, uint8_t *data) noexcept nogil:
+    cdef char *name = <char *>data
+    with gil:
+        opaque_container.pop(name)
+
+
+cdef class OpaqueContainer:
+    """A container that holds references to Python objects, indexed by uuid"""
+
+    def __cinit__(self):
+        self._by_name = {}
+
+    cdef lib.AVBufferRef *add(self, v):
+        cdef bytes uuid = str(uuid4()).encode("utf-8")
+        cdef lib.AVBufferRef *ref = lib.av_buffer_create(uuid, len(uuid), &key_free, NULL, 0)
+        self._by_name[uuid] = v
+        return ref
+
+    cdef object get(self, bytes name):
+        return self._by_name.get(name)
+
+    cdef object pop(self, bytes name):
+        return self._by_name.pop(name)
+
+
+cdef opaque_container = OpaqueContainer()

--- a/av/packet.pyx
+++ b/av/packet.pyx
@@ -2,6 +2,7 @@ cimport libav as lib
 
 from av.bytesource cimport bytesource
 from av.error cimport err_check
+from av.opaque cimport opaque_container
 from av.utils cimport avrational_to_fraction, to_avrational
 
 
@@ -207,7 +208,7 @@ cdef class Packet(Buffer):
             self.ptr.flags &= ~(lib.AV_PKT_FLAG_CORRUPT)
 
     @property
-    def is_discard(self): 
+    def is_discard(self):
         return bool(self.ptr.flags & lib.AV_PKT_FLAG_DISCARD)
 
     @property
@@ -217,4 +218,17 @@ cdef class Packet(Buffer):
     @property
     def is_disposable(self):
         return bool(self.ptr.flags & lib.AV_PKT_FLAG_DISPOSABLE)
+
+    @property
+    def opaque(self):
+        if self.ptr.opaque_ref is not NULL:
+            return opaque_container.get(<char *> self.ptr.opaque_ref.data)
+
+    @opaque.setter
+    def opaque(self, v):
+        lib.av_buffer_unref(&self.ptr.opaque_ref)
+
+        if v is None:
+            return
+        self.ptr.opaque_ref = opaque_container.add(v)
 

--- a/include/libav.pxd
+++ b/include/libav.pxd
@@ -1,4 +1,5 @@
 include "libavutil/avutil.pxd"
+include "libavutil/buffer.pxd"
 include "libavutil/channel_layout.pxd"
 include "libavutil/dict.pxd"
 include "libavutil/error.pxd"

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -99,6 +99,9 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         AV_CODEC_FLAG_OUTPUT_CORRUPT
         AV_CODEC_FLAG_QPEL
         AV_CODEC_FLAG_DROPCHANGED
+        AV_CODEC_FLAG_RECON_FRAME
+        AV_CODEC_FLAG_COPY_OPAQUE
+        AV_CODEC_FLAG_FRAME_DURATION
         AV_CODEC_FLAG_PASS1
         AV_CODEC_FLAG_PASS2
         AV_CODEC_FLAG_LOOP_FILTER
@@ -392,6 +395,7 @@ cdef extern from "libavcodec/avcodec.h" nogil:
 
         uint8_t **base
         void *opaque
+        AVBufferRef *opaque_ref
         AVDictionary *metadata
         int flags
         int decode_error_flags
@@ -415,6 +419,10 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         int duration
 
         int64_t pos
+
+        void *opaque
+        AVBufferRef *opaque_ref
+
 
     cdef int avcodec_fill_audio_frame(
         AVFrame *frame,

--- a/include/libavutil/buffer.pxd
+++ b/include/libavutil/buffer.pxd
@@ -1,0 +1,9 @@
+from libc.stdint cimport uint8_t
+
+cdef extern from "libavutil/buffer.h" nogil:
+
+    AVBufferRef *av_buffer_create(uint8_t *data, size_t size, void (*free)(void *opaque, uint8_t *data), void *opaque, int flags)
+    void av_buffer_unref(AVBufferRef **buf)
+
+    cdef struct AVBufferRef:
+        uint8_t *data


### PR DESCRIPTION
Allows tagging AVPackets and AVFrames with any Python object and, when AV_CODEC_FLAG_COPY_OPAQUE is enabled, ffmpeg will take care of propagating the references to those objects from packets -> frames (decoders) and frames -> packets (encoders).

Example usage:
```python
import av
import time

container = av.open("video.mp4")
video_stream = container.streams.video[0]
video_stream.codec_context.copy_opaque = True  # Enable propagating `opaque` from packets to frames
for packet_idx, packet in enumerate(container.demux()):
    packet.opaque = (time.time(), packet_idx)  # Could be any Python object (dataclass, str, float, etc)
    frames = packet.decode()
    print(f"Packet #{packet_idx} yielded {len(frames)} frames")
    for frame in frames:
        print(f"Decoded frame with opaque={frame.opaque}")
```