### PR TITLE
Add ffmpeg version info

### DIFF
--- a/av/__init__.py
+++ b/av/__init__.py
@@ -1,6 +1,6 @@
 # MUST import the core before anything else in order to initialize the underlying
 # library that is being wrapped.
-from av._core import time_base, library_versions
+from av._core import time_base, library_versions, ffmpeg_version_info
 
 # Capture logging (by importing it).
 from av import logging
@@ -32,6 +32,7 @@ AVError = FFmpegError  # noqa: F405
 __all__ = (
     "__version__",
     "time_base",
+    "ffmpeg_version_info",
     "library_versions",
     "AudioCodecContext",
     "AudioFifo",

--- a/av/_core.pyi
+++ b/av/_core.pyi
@@ -7,5 +7,6 @@ class _Meta(TypedDict):
 
 library_meta: dict[str, _Meta]
 library_versions: dict[str, tuple[int, int, int]]
+ffmpeg_version_info: str
 
 time_base: int

--- a/av/_core.pyx
+++ b/av/_core.pyx
@@ -18,6 +18,12 @@ cdef decode_version(v):
 
     return (major, minor, micro)
 
+# Return an informative version string.
+# This usually is the actual release version number or a git commit
+# description. This string has no fixed format and can change any time. It
+# should never be parsed by code.
+ffmpeg_version_info = lib.av_version_info()
+
 library_meta = {
     "libavutil": dict(
         version=decode_version(lib.avutil_version()),

--- a/include/libavutil/avutil.pxd
+++ b/include/libavutil/avutil.pxd
@@ -12,6 +12,7 @@ cdef extern from "libavutil/rational.h" nogil:
 
 cdef extern from "libavutil/avutil.h" nogil:
 
+    cdef const char* av_version_info()
     cdef int   avutil_version()
     cdef char* avutil_configuration()
     cdef char* avutil_license()

--- a/scripts/test
+++ b/scripts/test
@@ -18,6 +18,8 @@ istest() {
     return $?
 }
 
+$PYAV_PYTHON -c "import av; print(f'PyAV: {av.__version__}'); print(f'FFMPEG: {av.ffmpeg_version_info}')"
+
 if istest main; then
     $PYAV_PYTHON -m pytest
 fi


### PR DESCRIPTION
I'm not sure how you feel about this, but I can't really keep track of all the different version of ffmpeg internal libraries. the "friendly name" is really useful to know.

Let me know what you think.

* For ffmpeg 6.1.2. this returns "6.1.2"
* For ffmpeg 7(.0.0) this returns "7.0"
* For ffmpeg 7.0.2 this returns "7.0.2"
* For ffmpeg 7.1(.0) this returns "7.1"

I find the alignment with the branding much easier to communicate across developers.