### PR TITLE
CFLAGS in Makefile does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 LDFLAGS ?= ""
-CFLAGS ?= "-O0 -Wno-incompatible-pointer-types"
+CFLAGS ?= "-O0 -Wno-incompatible-pointer-types -Wno-unreachable-code"
 
 PYAV_PYTHON ?= python
 PYAV_PIP ?= pip

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 LDFLAGS ?= ""
-CFLAGS ?= "-O0 -Wno-incompatible-function-pointer-types"
+CFLAGS ?= "-O0 -Wno-incompatible-pointer-types"
 
 PYAV_PYTHON ?= python
 PYAV_PIP ?= pip


### PR DESCRIPTION
A quick search in GCC source code show that `-Wno-incompatible-function-pointer-types` does not exist as a flag. However, there is the close flag `-Wno-incompatible-pointer-types`