### PR TITLE
Remove `CodecContext.close()`

### DIFF
--- a/av/audio/stream.pyi
+++ b/av/audio/stream.pyi
@@ -30,5 +30,3 @@ class AudioStream(Stream):
     type: Literal["audio"]
     format: _Format
     layout: _Layout
-
-    def close(self, strict: bool = True) -> None: ...

--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -30,7 +30,6 @@ cdef class CodecContext:
 
     # Public API.
     cpdef open(self, bint strict=?)
-    cpdef close(self, bint strict=?)
 
     cdef _set_default_time_base(self)
 

--- a/av/codec/context.pyi
+++ b/av/codec/context.pyi
@@ -99,7 +99,6 @@ class CodecContext:
     delay: bool
 
     def open(self, strict: bool = True) -> None: ...
-    def close(self, strict: bool = True) -> None: ...
     @staticmethod
     def create(
         codec: str | Codec, mode: Literal["r", "w"] | None = None

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -254,13 +254,6 @@ cdef class CodecContext:
         self.ptr.time_base.num = 1
         self.ptr.time_base.den = lib.AV_TIME_BASE
 
-    cpdef close(self, bint strict=True):
-        if not self._is_open:
-            if strict:
-                raise ValueError("CodecContext is already closed.")
-            return
-        self._is_open = False
-        lib.avcodec_free_context(&self.ptr)
 
     def __dealloc__(self):
         if self.ptr and self.extradata_set:

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -246,8 +246,7 @@ cdef class OutputContainer(Container):
 
     def close(self):
         for stream in self.streams:
-            if stream.codec_context:
-                stream.codec_context.close(strict=False)
+            del stream
 
         close_output(self)
 

--- a/av/video/stream.pyi
+++ b/av/video/stream.pyi
@@ -40,5 +40,3 @@ class VideoStream(Stream):
     color_trc: int
     colorspace: int
     type: Literal["video"]
-
-    def close(self, strict: bool = True) -> None: ...

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -35,14 +35,14 @@ class TestStreams:
         data = container.streams.data[0]
         assert data == container.streams.best("data")
 
-    def test_printing_closed_video_stream(self) -> None:
+    def test_printing_video_stream(self) -> None:
         input_ = av.open(
             fate_suite("amv/MTV_high_res_320x240_sample_Penguin_Joke_MTV_from_WMV.amv")
         )
         container = av.open("out.mkv", "w")
 
         video_stream = container.add_stream("h264", rate=30)
-        # encoder = video_stream.codec.name + ""
+        encoder = video_stream.codec.name
 
         video_stream.width = input_.streams.video[0].width
         video_stream.height = input_.streams.video[0].height
@@ -52,19 +52,8 @@ class TestStreams:
             container.mux(video_stream.encode(frame))
             break
 
-        encoder = "libx264"
         repr = f"{video_stream}"
         assert repr.startswith(f"<av.VideoStream #0 {encoder}, yuv420p 160x120 at ")
-        assert repr.endswith(">")
-
-        # repr = f"{video_stream}"
-        # assert repr.startswith(f"<av.VideoStream #0 {encoder}, yuv420p 160x120 at ")
-        # assert repr.endswith(">")
-
-        video_stream.close()
-
-        repr = f"{video_stream}"
-        assert repr.startswith(f"<av.VideoStream #0 {encoder}, yuv420p 0x0 at ")
         assert repr.endswith(">")
 
         container.close()


### PR DESCRIPTION
Use `del` instead. This fixes many null pointer dereferences.