### PR TITLE
Remove `template` arg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,11 @@ Major:
 
 - Drop FFmpeg 6.
 - Remove ``AVError`` alias (use ``FFmpegError`` directly instead).
+- Remove the `template` arg from ``OutputContainer.add_stream()``.
+
+Features:
+
+- Add ``OutputContainer.add_stream_from_template()`` by :gh-user:`WyattBlue` and :gh-user:`cdce8p`.
 
 v13.1.0
 -------

--- a/av/container/output.pyi
+++ b/av/container/output.pyi
@@ -17,34 +17,22 @@ class OutputContainer(Container):
         self,
         codec_name: Literal["pcm_s16le", "aac", "mp3", "mp2"],
         rate: int | None = None,
-        template: None = None,
         options: dict[str, str] | None = None,
         **kwargs,
     ) -> AudioStream: ...
     @overload
     def add_stream(
         self,
-        codec_name: Literal["h264", "mpeg4", "png", "qtrle"],
+        codec_name: Literal["h264", "hevc", "mpeg4", "png", "gif", "qtrle"],
         rate: Fraction | int | None = None,
-        template: None = None,
         options: dict[str, str] | None = None,
         **kwargs,
     ) -> VideoStream: ...
     @overload
     def add_stream(
         self,
-        codec_name: None = None,
+        codec_name: str,
         rate: Fraction | int | None = None,
-        template: _StreamT | None = None,
-        options: dict[str, str] | None = None,
-        **kwargs,
-    ) -> _StreamT: ...
-    @overload
-    def add_stream(
-        self,
-        codec_name: str | None = None,
-        rate: Fraction | int | None = None,
-        template: Stream | None = None,
         options: dict[str, str] | None = None,
         **kwargs,
     ) -> Stream: ...


### PR DESCRIPTION
Use `add_stream_from_template()` as a replacement. This untested argument makes writing type stubs more complex than it needs to.