### PR TITLE
added support for srt

### DIFF
--- a/scripts/build-deps
+++ b/scripts/build-deps
@@ -44,6 +44,7 @@ echo ./configure
     --enable-sse \
     --enable-avx \
     --enable-avx2 \
+    --enable-libsrt \
     --prefix="$PYAV_LIBRARY_PREFIX" \
     || exit 2
 echo


### PR DESCRIPTION
This will solve: https://github.com/PyAV-Org/PyAV/discussions/1503

I would like to set up a test for this, but I don't know how to start streaming a video in pyav. I was able to create a network live stream with this:
`ffmpeg -i local_file.mp4 -c:v libx264 -f mpegts 'srt://127.0.0.1:40052?mode=listener&latency=2000000'`

I then opened the network stream with:
```
path = "srt://127.0.0.1:40052?mode=caller"
container = av.open(path)
```

Pyav decoded the network stream and everything seemed to work. 

If anyone knows how to create a network stream in pyav, I could write a test for this.