### PR TITLE
Add qmin and qmax parameters to the codec context

### DIFF
--- a/av/video/codeccontext.pyi
+++ b/av/video/codeccontext.pyi
@@ -26,6 +26,8 @@ class VideoCodecContext(CodecContext):
     color_primaries: int
     color_trc: int
     colorspace: int
+    qmin: int
+    qmax: int
     type: Literal["video"]
 
     def encode(self, frame: VideoFrame | None = None) -> list[Packet]: ...

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -278,3 +278,33 @@ cdef class VideoCodecContext(CodecContext):
     @max_b_frames.setter
     def max_b_frames(self, value):
         self.ptr.max_b_frames = value
+
+    @property
+    def qmin(self):
+        """
+        The minimum quantiser value of an encoded stream.
+
+        Wraps :ffmpeg:`AVCodecContext.qmin`.
+
+        :type: int
+        """
+        return self.ptr.qmin
+
+    @qmin.setter
+    def qmin(self, value):
+        self.ptr.qmin = value
+
+    @property
+    def qmax(self):
+        """
+        The maximum quantiser value of an encoded stream.
+
+        Wraps :ffmpeg:`AVCodecContext.qmax`.
+
+        :type: int
+        """
+        return self.ptr.qmax
+
+    @qmax.setter
+    def qmax(self, value):
+        self.ptr.qmax = value


### PR DESCRIPTION
Allows applications to control the min and max quantisers used for encoding.

Also add a test to ensure the encoder is behaving as we expect.

(Just to explain the context here a bit, we're making much more use of PyAV in our standard Raspberry Pi software, so hopefully this will generate quite a few new users. I'm keen to get the tweaks and small new features on our fork back onto mainline here, because that's better for everyone, so there will probably be "a few" small pull requests like this. Thanks!)