### PR TITLE
Cleanup `AVStream.side_data` leftovers

### DIFF
--- a/av/stream.pxd
+++ b/av/stream.pxd
@@ -12,8 +12,6 @@ cdef class Stream:
     # Stream attributes.
     cdef readonly Container container
     cdef readonly dict metadata
-    cdef readonly int nb_side_data
-    cdef readonly dict side_data
 
     # CodecContext attributes.
     cdef readonly CodecContext codec_context

--- a/av/stream.pyi
+++ b/av/stream.pyi
@@ -1,14 +1,8 @@
-from enum import Enum
 from fractions import Fraction
-from typing import ClassVar, Literal
+from typing import Literal
 
 from .codec import Codec, CodecContext
 from .container import Container
-from .frame import Frame
-from .packet import Packet
-
-class SideData(Enum):
-    DISPLAYMATRIX: ClassVar[SideData]
 
 class Stream:
     name: str | None

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -1,5 +1,4 @@
 cimport libav as lib
-from libc.stdint cimport int32_t
 
 from enum import Enum
 
@@ -14,11 +13,6 @@ from av.utils cimport (
 
 
 cdef object _cinit_bypass_sentinel = object()
-
-# If necessary more can be added from
-# https://ffmpeg.org/doxygen/trunk/group__lavc__packet.html#ga9a80bfcacc586b483a973272800edb97
-class SideData(Enum):
-    DISPLAYMATRIX: "Display Matrix" = lib.AV_PKT_DATA_DISPLAYMATRIX
 
 cdef Stream wrap_stream(Container container, lib.AVStream *c_stream, CodecContext codec_context):
     """Build an av.Stream for an existing AVStream.
@@ -84,7 +78,7 @@ cdef class Stream:
         self.codec_context = codec_context
         if self.codec_context:
             self.codec_context.stream_index = stream.index
-        
+
         self.metadata = avdict_to_dict(
             stream.metadata,
             encoding=self.container.metadata_encoding,


### PR DESCRIPTION
`AVStream.side_data` has been removed in #1570 so I think the type stubs and other leftovers from #1249 should be removed as well.

I didn't delete [`AVPacketSideDataType`](https://github.com/PyAV-Org/PyAV/blob/bf03325c967e6102e26734dcde813902e32b977a/include/libavcodec/avcodec.pxd#L300-L338) because maybe we'd like to add this back to [`AvPacket.side_data`](https://ffmpeg.org/doxygen/trunk/structAVPacket.html#ac55bfef91c33f02704ba76518d0f294c) to match the upstream FFmpeg API.