### PR TITLE
Add support for external flags in hwaccel

### DIFF
--- a/av/codec/hwaccel.pxd
+++ b/av/codec/hwaccel.pxd
@@ -18,3 +18,4 @@ cdef class HWAccel:
     cdef lib.AVBufferRef *ptr
     cdef public bint allow_software_fallback
     cdef public dict options
+    cdef public int flags

--- a/av/codec/hwaccel.pyi
+++ b/av/codec/hwaccel.pyi
@@ -42,6 +42,7 @@ class HWAccel:
         device: str | None = None,
         allow_software_fallback: bool = False,
         options: dict[str, object] | None = None,
+        flags: int | None = None,
     ) -> None: ...
     def create(self, codec: Codec) -> HWAccel: ...
 

--- a/av/codec/hwaccel.pyx
+++ b/av/codec/hwaccel.pyx
@@ -95,7 +95,7 @@ cpdef hwdevices_available():
 
 
 cdef class HWAccel:
-    def __init__(self, device_type, device=None, allow_software_fallback=True, options=None):
+    def __init__(self, device_type, device=None, allow_software_fallback=True, options=None, flags=None):
         if isinstance(device_type, HWDeviceType):
             self._device_type = device_type
         elif isinstance(device_type, str):
@@ -108,6 +108,7 @@ cdef class HWAccel:
         self._device = device
         self.allow_software_fallback = allow_software_fallback
         self.options = {} if not options else dict(options)
+        self.flags = 0 if not flags else flags
         self.ptr = NULL
         self.config = None
 
@@ -132,7 +133,7 @@ cdef class HWAccel:
 
         err_check(
             lib.av_hwdevice_ctx_create(
-                &self.ptr, config.ptr.device_type, c_device, c_options.ptr, 0
+                &self.ptr, config.ptr.device_type, c_device, c_options.ptr, self.flags
             )
         )
 


### PR DESCRIPTION
`AV_HWDEVICE_TYPE_CUDA` supports [`AV_CUDA_USE_CURRENT_CONTEXT`](https://chromium.googlesource.com/chromium/third_party/ffmpeg/+/refs/heads/master/libavutil/hwcontext_cuda.h#68) flag to re-use an exising CUDA context of the application, reducing vram usage when other CUDA kernels are used.