### PR TITLE
add Bayer pixel formats

### DIFF
--- a/av/video/format.pyi
+++ b/av/video/format.pyi
@@ -6,7 +6,10 @@ class VideoFormat:
     has_palette: bool
     is_bit_stream: bool
     is_planar: bool
-    is_rgb: bool
+    @property
+    def is_rgb(self) -> bool: ...
+    @property
+    def is_bayer(self) -> bool: ...
     width: int
     height: int
     components: tuple[VideoFormatComponent, ...]

--- a/av/video/format.pyx
+++ b/av/video/format.pyx
@@ -104,7 +104,12 @@ cdef class VideoFormat:
     def is_rgb(self):
         """The pixel format contains RGB-like data (as opposed to YUV/grayscale)."""
         return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_RGB)
+    
 
+    @property
+    def is_bayer(self):
+        """The pixel format contains Bayer data (as opposed to RGB)."""
+        return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_BAYER)
 
     cpdef chroma_width(self, int luma_width=0):
         """chroma_width(luma_width=0)

--- a/av/video/format.pyx
+++ b/av/video/format.pyx
@@ -108,7 +108,7 @@ cdef class VideoFormat:
 
     @property
     def is_bayer(self):
-        """The pixel format contains Bayer data (as opposed to RGB)."""
+        """The pixel format contains Bayer data."""
         return bool(self.ptr.flags & lib.AV_PIX_FMT_FLAG_BAYER)
 
     cpdef chroma_width(self, int luma_width=0):

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -464,8 +464,9 @@ cdef class VideoFrame(Frame):
                 # Planes where U and V are interleaved have the same stride as Y.
                 linesizes = (array.strides[0], array.strides[0])
         elif format in ("bayer_bggr8", "bayer_rggb8", "bayer_gbrg8", "bayer_grbg8","bayer_bggr16le", "bayer_rggb16le", "bayer_gbrg16le", "bayer_grbg16le","bayer_bggr16be", "bayer_rggb16be", "bayer_gbrg16be", "bayer_grbg16be"):
-            dtype = np.uint8 if format.endswith("8") else np.uint16
-            check_ndarray(array, dtype.__name__, 2)
+            check_ndarray(array, "uint8" if format.endswith("8") else "uint16", 2)            
+            check_ndarray_shape(array, array.shape[0] % 2 == 0)
+            check_ndarray_shape(array, array.shape[1] % 2 == 0)
     
             if array.strides[1] != (1 if format.endswith("8") else 2):
                 raise ValueError("provided array does not have C_CONTIGUOUS rows")

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -464,9 +464,7 @@ cdef class VideoFrame(Frame):
                 # Planes where U and V are interleaved have the same stride as Y.
                 linesizes = (array.strides[0], array.strides[0])
         elif format in ("bayer_bggr8", "bayer_rggb8", "bayer_gbrg8", "bayer_grbg8","bayer_bggr16le", "bayer_rggb16le", "bayer_gbrg16le", "bayer_grbg16le","bayer_bggr16be", "bayer_rggb16be", "bayer_gbrg16be", "bayer_grbg16be"):
-            check_ndarray(array, "uint8" if format.endswith("8") else "uint16", 2)            
-            check_ndarray_shape(array, array.shape[0] % 2 == 0)
-            check_ndarray_shape(array, array.shape[1] % 2 == 0)
+            check_ndarray(array, "uint8" if format.endswith("8") else "uint16", 2)
     
             if array.strides[1] != (1 if format.endswith("8") else 2):
                 raise ValueError("provided array does not have C_CONTIGUOUS rows")
@@ -663,13 +661,6 @@ cdef class VideoFrame(Frame):
             flat = array.reshape(-1)
             copy_array_to_plane(flat[:uv_start], frame.planes[0], 1)
             copy_array_to_plane(flat[uv_start:], frame.planes[1], 2)
-            return frame
-        elif format in {"bayer_bggr8", "bayer_rggb8", "bayer_grbg8", "bayer_gbrg8", "bayer_bggr16be", "bayer_bggr16le", "bayer_rggb16be", "bayer_rggb16le", "bayer_grbg16be", "bayer_grbg16le", "bayer_gbrg16be", "bayer_gbrg16le"}:
-            check_ndarray(array, "uint8" if format.endswith("8") else "uint16", 2)
-            check_ndarray_shape(array, array.shape[0] % 2 == 0)
-            check_ndarray_shape(array, array.shape[1] % 2 == 0)
-            frame = VideoFrame(array.shape[1], array.shape[0], format)
-            copy_array_to_plane(array if format.endswith("8") else byteswap_array(array, format.endswith("be")), frame.planes[0], 1 if format.endswith("8") else 2)
             return frame
         else:
             raise ValueError(f"Conversion from numpy array with format `{format}` is not yet supported")

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -463,7 +463,7 @@ cdef class VideoFrame(Frame):
             else:
                 # Planes where U and V are interleaved have the same stride as Y.
                 linesizes = (array.strides[0], array.strides[0])
-        elif format in ("bayer_bggr8", "bayer_rggb8", "bayer_gbrg8", "bayer_grbg8","bayer_bggr16le", "bayer_rggb16le", "bayer_gbrg16le", "bayer_grbg16le","bayer_bggr16be", "bayer_rggb16be", "bayer_gbrg16be", "bayer_grbg16be"):
+        elif format in {"bayer_bggr8", "bayer_rggb8", "bayer_gbrg8", "bayer_grbg8","bayer_bggr16le", "bayer_rggb16le", "bayer_gbrg16le", "bayer_grbg16le","bayer_bggr16be", "bayer_rggb16be", "bayer_gbrg16be", "bayer_grbg16be"}:
             check_ndarray(array, "uint8" if format.endswith("8") else "uint16", 2)
     
             if array.strides[1] != (1 if format.endswith("8") else 2):


### PR DESCRIPTION
This PR extends support for Bayer pixel formats in `VideoFrame`.
The enhancement makes it easier to work with Bayer formatted data in computer vision and video processing workflows.

- Create Bayer `VideoFrame` from `ndarray` or `bytes`
- Convert Bayer `VideoFrame` to  `ndarray`
- Check if a `VideoFormat` is a Bayer-like with its `is_bayer` property

| 8-bit            | 16-bit (little-endian) | 16-bit  (big-endian) |
|-----------------|----------------------------|---------------------------|
| `bayer_bggr8`  | `bayer_bggr16le`           | `bayer_bggr16be`         |
| `bayer_rggb8`  | `bayer_rggb16le`           | `bayer_rggb16be`         |
| `bayer_gbrg8`  | `bayer_gbrg16le`           | `bayer_gbrg16be`         |
| `bayer_grbg8`  | `bayer_grbg16le`           | `bayer_grbg16be`         |

