### PR TITLE
Stop publishing sdist

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,24 +4,6 @@ on:
     types: [published]
   workflow_dispatch:
 jobs:
-  package-source:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Build source package
-        run: |
-          pip install setuptools cython
-          python scripts/fetch-vendor.py --config-file scripts/ffmpeg-7.1.json /tmp/vendor
-          PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig python setup.py sdist
-      - name: Upload source package
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-source
-          path: dist/
-
   package-wheel:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -82,7 +64,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [package-source, package-wheel]
+    needs: [package-wheel]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,0 @@
-include *.txt *.md
-recursive-include av *.pyx *.pxd
-recursive-include docs *.rst *.py
-recursive-include examples *.py
-recursive-include include *.pxd *.h
-recursive-include src/av *.c *.h
-recursive-include tests *.py

--- a/README.md
+++ b/README.md
@@ -32,20 +32,10 @@ conda install av -c conda-forge
 See the [Conda install][conda-install] docs to get started with (mini)Conda.
 
 
-Alternative installation methods
---------------------------------
+Installing From Source
+----------------------
 
-Due to the complexity of the dependencies, PyAV is not always the easiest Python package to install from source. If you want to use your existing ffmpeg (must be the correct major version), the source version of PyAV is on [PyPI][pypi]:
-
-```bash
-pip install av --no-binary av
-```
-
-> [!WARNING]
-> This installation method won't work for Windows or Debian based systems.
-
-
-And if you want to build from the absolute source (POSIX only):
+Here's how to build PyAV from source source. You must use [MSYS2](https://www.msys2.org/) when using Windows.
 
 ```bash
 git clone https://github.com/PyAV-Org/PyAV.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,52 @@
 [build-system]
-requires = ["setuptools", "cython"]
+requires = ["setuptools>61", "cython>=3,<4"]
+
+[project]
+name = "av"
+description = "Pythonic bindings for FFmpeg's libraries."
+readme = "README.md"
+license = {text = "BSD-3-Clause"}
+authors = [
+    {name = "WyattBlue", email = "wyattblue@auto-editor.com"},
+    {name = "Jeremy Lainé", email = "jeremy.laine@m4x.org"},
+]
+requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Cython",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Sound/Audio :: Conversion",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Multimedia :: Video :: Conversion",
+]
+dynamic = ["version"]
+
+[tool.setuptools]
+zip-safe = false
+
+[tool.setuptools.dynamic]
+version = {attr = "av.about.__version__"}
+
+[project.urls]
+"Bug Tracker" = "https://github.com/PyAV-Org/PyAV/discussions/new?category=4-bugs"
+"Source Code" = "https://github.com/PyAV-Org/PyAV"
+homepage = "https://pyav.basswood-io.com"
+
+[project.scripts]
+"pyav" = "av.__main__:main"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
sdist takes ~4MB of space, is neglected by PyPA, and is a bad experience for both the developer and the user. PyAV does not have universal support for every arch, and removing source builds in PyPI does not change that.