### PR TITLE
Add yuv420p10le pix_fmt

### DIFF
--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -485,6 +485,15 @@ def test_ndarray_yuv444p16() -> None:
         assertNdarraysEqual(frame.to_ndarray(), array)
 
 
+def test_ndarray_yuv420p10le() -> None:
+    array = numpy.random.randint(0, 65536, size=(3, 480, 640), dtype=numpy.uint16)
+    for format in ("yuv420p10le",):
+        frame = VideoFrame.from_ndarray(array, format=format)
+        assert frame.width == 640 and frame.height == 480
+        assert frame.format.name == format
+        assert format in av.video.frame.supported_np_pix_fmts
+
+
 def test_ndarray_yuv422p10le() -> None:
     array = numpy.random.randint(0, 65536, size=(3, 480, 640), dtype=numpy.uint16)
     for format in ("yuv422p10le",):


### PR DESCRIPTION
Adds support for the `yuv420p10le` pixel format.

Based on: https://github.com/PyAV-Org/PyAV/pull/1767/files
