### PR TITLE
Enable libx265 for ffmpeg in build-deps

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -57,13 +57,13 @@ jobs:
           ubuntu-24.04)
             sudo apt-get update
             sudo apt-get install autoconf automake build-essential cmake \
-              libtool pkg-config nasm zlib1g-dev libvorbis-dev libx264-dev
+              libtool pkg-config nasm zlib1g-dev libvorbis-dev libx264-dev libx265-dev
             if [[ "${{ matrix.config.extras }}" ]]; then
               sudo apt-get install doxygen wget
             fi
             ;;
           macos-14)
-            brew install automake libtool nasm libpng libvorbis libvpx opus x264
+            brew install automake libtool nasm libpng libvorbis libvpx opus x264 x265
             ;;
         esac
 

--- a/scripts/build-deps
+++ b/scripts/build-deps
@@ -63,6 +63,7 @@ echo ./configure
     --enable-gpl \
     --enable-version3 \
     --enable-libx264 \
+    --enable-libx265 \
     --enable-libxml2 \
     --enable-shared \
     --enable-sse \


### PR DESCRIPTION
When building `FFmpeg` as a dependency, the current build does not include `libx265`. 

It appears that release `PyAV` versions do support `libx265`. I'm guessing this change only affects development or those who build from source.
