### PR TITLE
Bump setuptools requirement for PEP 639 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>61", "cython>=3.1.0a1,<4"]
+requires = ["setuptools>=77.0", "cython>=3.1.0a1,<4"]
 
 [project]
 name = "av"


### PR DESCRIPTION
Followup to https://github.com/PyAV-Org/PyAV/pull/1860
Support for PEP 639 was only added in setuptools `v77`.