### PR TITLE
Expose the Duration Field for Frames

### DIFF
--- a/av/frame.pyi
+++ b/av/frame.pyi
@@ -9,6 +9,7 @@ class SideData(TypedDict, total=False):
 class Frame:
     dts: int | None
     pts: int | None
+    duration: int | None
     time_base: Fraction
     side_data: SideData
     opaque: object

--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -53,6 +53,9 @@ cdef class Frame:
         if self.ptr.pts != lib.AV_NOPTS_VALUE:
             self.ptr.pts = lib.av_rescale_q(self.ptr.pts, self._time_base, dst)
 
+        if self.ptr.duration != 0:
+            self.ptr.duration = lib.av_rescale_q(self.ptr.duration, self._time_base, dst)
+
         self._time_base = dst
 
     @property
@@ -94,6 +97,24 @@ cdef class Frame:
             self.ptr.pts = lib.AV_NOPTS_VALUE
         else:
             self.ptr.pts = value
+
+    @property
+    def duration(self):
+        """
+        The duration of the frame in :attr:`time_base` units
+
+        :type: int
+        """
+        if self.ptr.duration == 0:
+            return None
+        return self.ptr.duration
+
+    @duration.setter
+    def duration(self, value):
+        if value is None:
+            self.ptr.duration = 0
+        else:
+            self.ptr.duration = value
 
     @property
     def time(self):

--- a/av/video/frame.pyi
+++ b/av/video/frame.pyi
@@ -30,6 +30,7 @@ class PictureType(IntEnum):
 class VideoFrame(Frame):
     format: VideoFormat
     pts: int
+    duration: int
     planes: tuple[VideoPlane, ...]
     pict_type: int
     colorspace: int

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -461,6 +461,8 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         AVColorTransferCharacteristic color_trc
         AVColorSpace colorspace
 
+        int64_t duration
+
     cdef AVFrame* avcodec_alloc_frame()
 
     cdef struct AVPacket:


### PR DESCRIPTION
This PR exposes the [duration](https://ffmpeg.org/doxygen/trunk/structAVFrame.html#ab90bd20a44c79c144045916b00c50e0d ) field on frame objects as the time that a given frame should be displayed for in `time_base` units. 

This can simplify certain decode loops which are searching for specific frames in time, e.g.: 

```
for frame in container.decode(video=0):
  if (frame.pts <= target_time_pts <= frame.pts + frame.duration):
    break # Found it
```

In this example the frame might not occur *at* the target pts so we need to use duration to check if the frame would be onscreen at the target time.

Currently this can be done by computing an average frame duration using the average frame rate (which is error prone) or trying to synchronize to the packets duration field.