### PR TITLE
Update FFmpeg build to use libvpx 1.15.1 and libxml2 2.14.3

### DIFF
--- a/scripts/ffmpeg-7.1.json
+++ b/scripts/ffmpeg-7.1.json
@@ -1,3 +1,3 @@
 {
-    "url": "https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/7.1.1-2/ffmpeg-{platform}.tar.gz"
+    "url": "https://github.com/PyAV-Org/pyav-ffmpeg/releases/download/7.1.1-4/ffmpeg-{platform}.tar.gz"
 }


### PR DESCRIPTION
libvpx 1.14.0 is vulnerable to CVE-2024-5197.

libxml2 2.9.13 is vulnerable to CVE-2022-2309, CVE-2023-29469, CVE-2017-5130, CVE-2023-45322, CVE-2024-25062, CVE-2022-40303, CVE-2022-40304, CVE-2023-28484, CVE-2022-29824

Fixes: #1892
Fixes: #1894