### PR TITLE
Make container/output pure

### DIFF
--- a/av/container/output.pxd
+++ b/av/container/output.pxd
@@ -5,7 +5,6 @@ from av.stream cimport Stream
 
 
 cdef class OutputContainer(Container):
-
     cdef bint _started
     cdef bint _done
     cdef lib.AVPacket *packet_ptr


### PR DESCRIPTION
This also syncs the QoL changes I've made in basswood-av. "Pure" stands for Cython's "Pure Python" mode, a way to write Cython in the Python grammar.