### PR TITLE
Allow user to set its own PYAV_TESTDATA_DIR in tests/common.py

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -66,7 +66,7 @@ def asset(*args: str) -> str:
 
 
 # Store all of the sample data here.
-os.environ["PYAV_TESTDATA_DIR"] = asset()
+os.environ.setdefault("PYAV_TESTDATA_DIR", asset())
 
 
 def fate_png() -> str:


### PR DESCRIPTION
There was no user-friendly way to properly set the PYAV_TESTDATA_DIR, because `os.environ["PYAV_TESTDATA_DIR"] = asset()` overrides the previous value. Use `os.environ.setdefault("PYAV_TESTDATA_DIR", asset())` instead.