### PR TITLE
pyproject: Fix license field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=77.0", "cython>=3.1.0a1,<4"]
 name = "av"
 description = "Pythonic bindings for FFmpeg's libraries."
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 authors = [
     {name = "WyattBlue", email = "wyattblue@auto-editor.com"},
     {name = "Jeremy Lainé", email = "jeremy.laine@m4x.org"},


### PR DESCRIPTION
https://peps.python.org/pep-0621/#license