### PR TITLE
Install cython from conda-forge in smoke tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -127,14 +127,14 @@ jobs:
           pillow \
           pytest \
           python=${{ matrix.config.python }} \
-          setuptools
+          setuptools \
+          cython
 
     - name: Build
       shell: bash
       run: |
         . $CONDA/etc/profile.d/conda.sh
         conda activate pyav
-        pip install 'Cython==3.1.0a1'
         python scripts\\fetch-vendor.py --config-file scripts\\ffmpeg-${{ matrix.config.ffmpeg }}.json $CONDA_PREFIX\\Library
         python scripts\\comptime.py  ${{ matrix.config.ffmpeg }}
         python setup.py build_ext --inplace --ffmpeg-dir=$CONDA_PREFIX\\Library


### PR DESCRIPTION
While looking over the config for #1956 I noticed you're installing an old Cython alpha release and probably just want to install either nightlies or the newest release.

This installs the newest release from conda-forge.

Cython ships nightlies to the scientific-python repo: https://anaconda.org/scientific-python-nightly-wheels/cython