### PR TITLE
fixed seek operation when not at eof

### DIFF
--- a/av/container/input.pxd
+++ b/av/container/input.pxd
@@ -6,4 +6,6 @@ from av.stream cimport Stream
 
 cdef class InputContainer(Container):
 
+    cdef bint eof
+
     cdef flush_buffers(self)

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -173,6 +173,7 @@ cdef class InputContainer(Container):
                         ret = lib.av_read_frame(self.ptr, packet.ptr)
                     self.err_check(ret)
                 except EOFError:
+                    self.eof = True
                     break
 
                 if include_stream[packet.ptr.stream_index]:
@@ -276,7 +277,9 @@ cdef class InputContainer(Container):
             ret = lib.av_seek_frame(self.ptr, stream_index, c_offset, flags)
         err_check(ret)
 
-        self.flush_buffers()
+        # codec buffers must be cleared if file is at eof, 
+        if self.eof or lib.avio_feof(self.ptr.pb):
+            self.flush_buffers()
 
     cdef flush_buffers(self):
         self._assert_open()

--- a/include/libavformat/avformat.pxd
+++ b/include/libavformat/avformat.pxd
@@ -275,6 +275,8 @@ cdef extern from "libavformat/avformat.h" nogil:
 
     cdef int avio_closep(AVIOContext **s)
 
+    cdef int avio_feof(AVIOContext *s)
+
     cdef int avformat_find_stream_info(
         AVFormatContext *ctx,
         AVDictionary **options,  # Can be NULL.


### PR DESCRIPTION
This is a PR to resolve Issue #1987 ("Seek succeeds but any frame read is all zeros [revisited]") that I posted earlier.

The problem was that the said AVI format and configuration cannot have the codec buffer flushed if not at the end of the file. I studied FFmpeg's [`ffplay.c`](https://github.com/FFmpeg/FFmpeg/blob/master/fftools/ffplay.c) for their handling of during-playback seeks, and the only difference is that they do not flush the codec buffers. 

If we simply remove: https://github.com/PyAV-Org/PyAV/blob/0b85c60defbea05ee8118a0605f7c31254589a0b/av/container/input.pyx#L279
It fails the `test_decode_half` and `test_stream_seek` because seeking after reaching the EOF does not reinstate the codecs. To get the codecs output of the EOF, we must call `flush_buffers()`. 

To satisfy these conditions, this PR adds an `eof` flag to `InputContainer` and adopted the EOF checking mechanism from ffplay: https://github.com/FFmpeg/FFmpeg/blob/673f28b6cb6e20f5a695a90d144a6158bdf987fe/fftools/ffplay.c#L3098

P.S., I've also added `InputContainer.seek2()` method which wraps `avformat_seek_file()` to my fork while I was investigating this issue. I'd be happy to add it to this PR (or as another PR) if you find it a reasonable addition to the class.