### PR TITLE
Binding to AVChapter and chapters functions in Container class

### DIFF
--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -1,3 +1,5 @@
+from fractions import Fraction
+
 from cython.operator cimport dereference
 from libc.stdint cimport int64_t
 
@@ -329,6 +331,22 @@ cdef class Container:
     def flags(self, int value):
         self._assert_open()
         self.ptr.flags = value
+
+    def chapters(self):
+        self._assert_open()
+        cdef list result = []
+        cdef int i
+
+        for i in range(self.ptr.nb_chapters):
+            ch = self.ptr.chapters[i]
+            result.append({
+                "id": ch.id,
+                "start": ch.start,
+                "end": ch.end,
+                "time_base": Fraction(ch.time_base.num, ch.time_base.den),
+                "metadata": avdict_to_dict(ch.metadata, self.metadata_encoding, self.metadata_errors),
+            })
+        return result
 
 def open(
     file,

--- a/include/libavformat/avformat.pxd
+++ b/include/libavformat/avformat.pxd
@@ -44,6 +44,14 @@ cdef extern from "libavformat/avformat.h" nogil:
         AVRational r_frame_rate
         AVRational sample_aspect_ratio
 
+    cdef struct AVChapter:
+        int id
+        int64_t start
+        int64_t end
+        AVRational time_base
+        AVDictionary *metadata
+
+
     # http://ffmpeg.org/doxygen/trunk/structAVIOContext.html
     cdef struct AVIOContext:
         unsigned char* buffer
@@ -172,6 +180,9 @@ cdef extern from "libavformat/avformat.h" nogil:
         # Streams.
         unsigned int nb_streams
         AVStream **streams
+
+        unsigned int nb_chapters
+        AVChapter **chapters
 
         AVInputFormat *iformat
         AVOutputFormat *oformat


### PR DESCRIPTION
This PR add c bindings to [AVChapter](https://ffmpeg.org/doxygen/4.2/structAVChapter.html) struct and a method to list all chapters in a container.

Example usage:
```python
import av
container = av.open("video_with_chapter_marks.mp4")
chapters = container.chapters()

for chapter in chapters:
    print(f"id: {chapter['id']}, start: {chapter['start']}, end: {chapter['end']}, time_base: {chapter['time_base']}, metadata: {chapter['metadata']}")
```

The output should look like:
```
id: 0, start: 0, end: 5001, time_base: 1/1000, metadata: {'title': 'I0001'}
id: 1, start: 5001, end: 10001, time_base: 1/1000, metadata: {'title': 'I0002'}
id: 2, start: 10001, end: 30000, time_base: 1/1000, metadata: {'title': 'I0003'}
```

