### PR TITLE
Fix typos

### DIFF
--- a/AUTHORS.py
+++ b/AUTHORS.py
@@ -94,7 +94,7 @@ for email, count in sorted(email_count.items(), key=lambda x: (-x[1], x[0])):
     github = github_map.get(email)
 
     # The '-' vs '*' is so that Sphinx treats them as different lists, and
-    # introduces a gap bettween them.
+    # introduces a gap between them.
     if github:
         print(
             "%s %s <%s>; `@%s <https://github.com/%s>`_"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -559,7 +559,7 @@ Build:
 Other:
 
 - Incremental improvements to docs and tests.
-- Examples directory will now always be runnable as-is, and embeded in the docs (in a copy-pastable form).
+- Examples directory will now always be runnable as-is, and embedded in the docs (in a copy-pastable form).
 
 
 v6.0.0

--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -130,7 +130,7 @@ class Flags(Flag):
     non_block: "Do not block when reading packets from input." = lib.AVFMT_FLAG_NONBLOCK
     ign_dts: "Ignore DTS on frames that contain both DTS & PTS." = lib.AVFMT_FLAG_IGNDTS
     no_fillin: "Do not infer any values from other values, just return what is stored in the container." = lib.AVFMT_FLAG_NOFILLIN
-    no_parse: "Do not use AVParsers, you also must set AVFMT_FLAG_NOFILLIN as the fillin code works on frames and no parsing -> no frames. Also seeking to frames can not work if parsing to find frame boundaries has been disabled." = lib.AVFMT_FLAG_NOPARSE
+    no_parse: "Do not use AVParsers, you also must set AVFMT_FLAG_NOFILLIN as the fill in code works on frames and no parsing -> no frames. Also seeking to frames can not work if parsing to find frame boundaries has been disabled." = lib.AVFMT_FLAG_NOPARSE
     no_buffer: "Do not buffer frames when possible." = lib.AVFMT_FLAG_NOBUFFER
     custom_io: "The caller has supplied a custom AVIOContext, don't avio_close() it." = lib.AVFMT_FLAG_CUSTOM_IO
     discard_corrupt: "Discard frames marked corrupted." = lib.AVFMT_FLAG_DISCARD_CORRUPT

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -241,7 +241,7 @@ cdef class InputContainer(Container):
 
         In most cases, the defaults of ``backwards = True`` and ``any_frame = False``
         are the best course of action, followed by you demuxing/decoding to
-        the position that you want. This is becase to properly decode video frames
+        the position that you want. This is because to properly decode video frames
         you need to start from the previous keyframe.
 
         .. seealso:: :ffmpeg:`avformat_seek_file` for discussion of the flags.

--- a/av/error.pyx
+++ b/av/error.pyx
@@ -267,7 +267,7 @@ ErrorType = EnumType("ErrorType", (EnumItem, ), {"__module__": __name__}, [x[:2]
 
 
 for enum in ErrorType:
-    # Mimick the errno module.
+    # Mimic the errno module.
     globals()[enum.name] = enum
     if enum.value == c_PYAV_STASHED_ERROR:
         enum.strerror = PYAV_STASHED_ERROR_message
@@ -275,7 +275,7 @@ for enum in ErrorType:
         enum.strerror = lib.av_err2str(-enum.value)
 
 
-# Mimick the builtin exception types.
+# Mimic the builtin exception types.
 # See https://www.python.org/dev/peps/pep-3151/#new-exception-classes
 # Use the named ones we have, otherwise default to OSError for anything in errno.
 

--- a/av/sidedata/motionvectors.pyx
+++ b/av/sidedata/motionvectors.pyx
@@ -55,7 +55,7 @@ class MotionVectors(_MotionVectors, Sequence):
 cdef class MotionVector:
     def __init__(self, sentinel, _MotionVectors parent, int index):
         if sentinel is not _cinit_bypass_sentinel:
-            raise RuntimeError("cannot manually instatiate MotionVector")
+            raise RuntimeError("cannot manually instantiate MotionVector")
         self.parent = parent
         cdef lib.AVMotionVector *base = <lib.AVMotionVector*>parent.ptr.data
         self.ptr = base + index

--- a/av/sidedata/sidedata.pyx
+++ b/av/sidedata/sidedata.pyx
@@ -63,7 +63,7 @@ cdef int get_display_rotation(Frame frame):
 cdef class SideData(Buffer):
     def __init__(self, sentinel, Frame frame, int index):
         if sentinel is not _cinit_bypass_sentinel:
-            raise RuntimeError("cannot manually instatiate SideData")
+            raise RuntimeError("cannot manually instantiate SideData")
         self.frame = frame
         self.ptr = frame.ptr.side_data[index]
         self.metadata = wrap_dictionary(self.ptr.metadata)

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -217,13 +217,13 @@ cdef class VideoCodecContext(CodecContext):
         :type: int
         """
         if self.is_decoder:
-            raise RuntimeError("Cannnot access 'gop_size' as a decoder")
+            raise RuntimeError("Cannot access 'gop_size' as a decoder")
         return self.ptr.gop_size
 
     @gop_size.setter
     def gop_size(self, int value):
         if self.is_decoder:
-            raise RuntimeError("Cannnot access 'gop_size' as a decoder")
+            raise RuntimeError("Cannot access 'gop_size' as a decoder")
         self.ptr.gop_size = value
 
     @property

--- a/av/video/format.pyx
+++ b/av/video/format.pyx
@@ -158,7 +158,7 @@ cdef class VideoFormatComponent:
 
     @property
     def is_luma(self):
-        """Is this compoment a luma channel?"""
+        """Is this component a luma channel?"""
         return self.index == 0 and (
             self.format.ptr.nb_components == 1 or
             self.format.ptr.nb_components == 2 or

--- a/docs/api/video.rst
+++ b/docs/api/video.rst
@@ -113,7 +113,7 @@ Enums
 .. autoclass:: av.video.reformatter.Colorspace
 
     Wraps the ``SWS_CS_*`` flags. There is a bit of overlap in
-    these names which comes from FFmpeg and backards compatibility.
+    these names which comes from FFmpeg and backwards compatibility.
 
     .. enumtable:: av.video.reformatter.Colorspace
 

--- a/tests/test_bitstream.py
+++ b/tests/test_bitstream.py
@@ -17,7 +17,7 @@ def is_annexb(packet: Packet | bytes | None) -> bool:
     return data[:3] == b"\0\0\x01" or data[:4] == b"\0\0\0\x01"
 
 
-def test_filters_availible() -> None:
+def test_filters_available() -> None:
     assert "h264_mp4toannexb" in bitstream_filters_available
 
 

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -415,7 +415,7 @@ def encode_frames_with_qminmax(
     frames: list[VideoFrame], shape: tuple[int, int, int], qminmax: tuple[int, int]
 ) -> int:
     """
-    Encode a video with the given quantiser limits, and return how many enocded
+    Encode a video with the given quantiser limits, and return how many encoded
     bytes we made in total.
 
     frames: the frames to encode


### PR DESCRIPTION
Found via `codespell -L wel,domin,ehr,bu,setts`