### PR TITLE
Add subtitle encoding support

### DIFF
--- a/av/subtitles/codeccontext.pxd
+++ b/av/subtitles/codeccontext.pxd
@@ -3,4 +3,5 @@ from av.packet cimport Packet
 
 
 cdef class SubtitleCodecContext(CodecContext):
+    cdef bint subtitle_header_set
     cpdef decode2(self, Packet packet)

--- a/av/subtitles/codeccontext.py
+++ b/av/subtitles/codeccontext.py
@@ -1,12 +1,108 @@
 import cython
 from cython.cimports import libav as lib
+from cython.cimports.av.bytesource import ByteSource, bytesource
 from cython.cimports.av.error import err_check
 from cython.cimports.av.packet import Packet
 from cython.cimports.av.subtitles.subtitle import SubtitleProxy, SubtitleSet
+from cython.cimports.cpython.bytes import PyBytes_FromStringAndSize
+from cython.cimports.libc.string import memcpy, strlen
 
 
 @cython.cclass
 class SubtitleCodecContext(CodecContext):
+    @property
+    def subtitle_header(self) -> bytes | None:
+        """Get the subtitle header data (ASS/SSA format for text subtitles)."""
+        if (
+            self.ptr.subtitle_header == cython.NULL
+            or self.ptr.subtitle_header_size <= 0
+        ):
+            return None
+        return PyBytes_FromStringAndSize(
+            cython.cast(cython.p_char, self.ptr.subtitle_header),
+            self.ptr.subtitle_header_size,
+        )
+
+    @subtitle_header.setter
+    def subtitle_header(self, data: bytes | None) -> None:
+        """Set the subtitle header data."""
+        source: ByteSource
+        if data is None:
+            lib.av_freep(cython.address(self.ptr.subtitle_header))
+            self.ptr.subtitle_header_size = 0
+        else:
+            source = bytesource(data)
+            self.ptr.subtitle_header = cython.cast(
+                cython.p_uchar,
+                lib.av_realloc(
+                    self.ptr.subtitle_header,
+                    source.length + lib.AV_INPUT_BUFFER_PADDING_SIZE,
+                ),
+            )
+            if not self.ptr.subtitle_header:
+                raise MemoryError("Cannot allocate subtitle_header")
+            memcpy(self.ptr.subtitle_header, source.ptr, source.length)
+            self.ptr.subtitle_header_size = source.length
+        self.subtitle_header_set = True
+
+    def __dealloc__(self) -> None:
+        if self.ptr and self.subtitle_header_set:
+            lib.av_freep(cython.address(self.ptr.subtitle_header))
+
+    def encode_subtitle(self, subtitle: SubtitleSet) -> Packet:
+        """
+        Encode a SubtitleSet into a Packet.
+
+        Args:
+            subtitle: The SubtitleSet to encode
+
+        Returns:
+            A Packet containing the encoded subtitle data
+        """
+        if not self.codec.ptr:
+            raise ValueError("Cannot encode with unknown codec")
+
+        self.open(strict=False)
+
+        # Calculate buffer size from subtitle text length
+        buf_size: cython.size_t = 0
+        i: cython.uint
+        for i in range(subtitle.proxy.struct.num_rects):
+            rect = subtitle.proxy.struct.rects[i]
+            if rect.ass != cython.NULL:
+                buf_size += strlen(rect.ass)
+            if rect.text != cython.NULL:
+                buf_size += strlen(rect.text)
+        buf_size += 1024  # padding for format overhead
+
+        buf: cython.p_uchar = cython.cast(cython.p_uchar, lib.av_malloc(buf_size))
+        if buf == cython.NULL:
+            raise MemoryError("Failed to allocate subtitle encode buffer")
+
+        ret: cython.int = lib.avcodec_encode_subtitle(
+            self.ptr,
+            buf,
+            buf_size,
+            cython.address(subtitle.proxy.struct),
+        )
+
+        if ret < 0:
+            lib.av_free(buf)
+            err_check(ret, "avcodec_encode_subtitle()")
+
+        packet: Packet = Packet(ret)
+        memcpy(packet.ptr.data, buf, ret)
+        lib.av_free(buf)
+
+        packet.ptr.pts = subtitle.proxy.struct.pts
+        packet.ptr.dts = subtitle.proxy.struct.pts
+        packet.ptr.duration = (
+            subtitle.proxy.struct.end_display_time
+            - subtitle.proxy.struct.start_display_time
+        )
+
+        return packet
+
     @cython.cfunc
     def _send_packet_and_recv(self, packet: Packet | None):
         if packet is None:

--- a/av/subtitles/codeccontext.pyi
+++ b/av/subtitles/codeccontext.pyi
@@ -6,4 +6,6 @@ from av.subtitles.subtitle import SubtitleSet
 
 class SubtitleCodecContext(CodecContext):
     type: Literal["subtitle"]
+    subtitle_header: bytes | None
     def decode2(self, packet: Packet) -> SubtitleSet | None: ...
+    def encode_subtitle(self, subtitle: SubtitleSet) -> Packet: ...

--- a/av/subtitles/subtitle.pyi
+++ b/av/subtitles/subtitle.pyi
@@ -5,8 +5,16 @@ class SubtitleSet:
     start_display_time: int
     end_display_time: int
     pts: int
-    rects: tuple[Subtitle]
+    rects: tuple[Subtitle, ...]
 
+    @staticmethod
+    def create(
+        text: bytes,
+        start: int,
+        end: int,
+        pts: int = 0,
+        subtitle_format: int = 1,
+    ) -> SubtitleSet: ...
     def __len__(self) -> int: ...
     def __iter__(self) -> Iterator[Subtitle]: ...
     def __getitem__(self, i: int) -> Subtitle: ...

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -289,6 +289,10 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         int extradata_size
         uint8_t *extradata
 
+        # Subtitle header (ASS/SSA format for text subtitles)
+        uint8_t *subtitle_header
+        int subtitle_header_size
+
         int delay
 
         AVCodec *codec

--- a/include/libavutil/avutil.pxd
+++ b/include/libavutil/avutil.pxd
@@ -110,9 +110,11 @@ cdef extern from "libavutil/avutil.h" nogil:
     cdef double M_PI
 
     cdef void* av_malloc(size_t size)
+    cdef void* av_mallocz(size_t size)
     cdef void *av_calloc(size_t nmemb, size_t size)
     cdef void *av_realloc(void *ptr, size_t size)
 
+    cdef void av_free(void *ptr)
     cdef void av_freep(void *ptr)
 
     cdef int av_get_bytes_per_sample(AVSampleFormat sample_fmt)

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -1,9 +1,12 @@
+import io
 from typing import cast
 
 import av
+from av.codec.context import CodecContext
+from av.subtitles.codeccontext import SubtitleCodecContext
 from av.subtitles.subtitle import AssSubtitle, BitmapSubtitle
 
-from .common import fate_suite
+from .common import TestCase, fate_suite
 
 
 class TestSubtitle:
@@ -73,3 +76,142 @@ class TestSubtitle:
                 subs.extend(stream.decode())
 
         assert len(subs) == 3
+
+    def test_subtitle_header_read(self) -> None:
+        """Test reading subtitle_header from a decoded subtitle stream."""
+        path = fate_suite("sub/MovText_capability_tester.mp4")
+
+        with av.open(path) as container:
+            stream = container.streams.subtitles[0]
+            ctx = cast(SubtitleCodecContext, stream.codec_context)
+            header = ctx.subtitle_header
+            assert header is None or isinstance(header, bytes)
+
+    def test_subtitle_header_write(self) -> None:
+        """Test setting subtitle_header on encoder context."""
+        ctx = cast(SubtitleCodecContext, CodecContext.create("mov_text", "w"))
+        assert ctx.subtitle_header is None
+
+        ass_header = b"[Script Info]\nScriptType: v4.00+\n"
+        ctx.subtitle_header = ass_header
+        assert ctx.subtitle_header == ass_header
+
+        new_header = b"[Script Info]\nScriptType: v4.00\n"
+        ctx.subtitle_header = new_header
+        assert ctx.subtitle_header == new_header
+
+        ctx.subtitle_header = None
+        assert ctx.subtitle_header is None
+
+
+class TestSubtitleEncoding(TestCase):
+    def test_subtitle_set_create(self) -> None:
+        """Test creating SubtitleSet for encoding."""
+        from av.subtitles.subtitle import SubtitleSet
+
+        text = b"0,0,Default,,0,0,0,,Hello World"
+        subtitle = SubtitleSet.create(text=text, start=0, end=2000, pts=0)
+
+        assert subtitle.format == 1
+        assert subtitle.start_display_time == 0
+        assert subtitle.end_display_time == 2000
+        assert subtitle.pts == 0
+        assert len(subtitle) == 1
+        assert cast(AssSubtitle, subtitle[0]).ass == text
+
+    def test_subtitle_encode_mp4(self) -> None:
+        """Test encoding subtitles to MP4 container."""
+        from av.subtitles.subtitle import SubtitleSet
+
+        ass_header = b"""[Script Info]
+ScriptType: v4.00+
+PlayResX: 640
+PlayResY: 480
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+
+        output = io.BytesIO()
+        with av.open(output, "w", format="mp4") as container:
+            # MP4 requires video for subtitles
+            video_stream = container.add_stream("libx264", rate=30)
+            video_stream.width = 640
+            video_stream.height = 480
+            video_stream.pix_fmt = "yuv420p"
+
+            sub_stream = container.add_stream("mov_text")
+            sub_ctx = cast(SubtitleCodecContext, sub_stream.codec_context)
+            sub_ctx.subtitle_header = ass_header
+
+            container.start_encoding()
+
+            frame = av.VideoFrame(640, 480, "yuv420p")
+            frame.pts = 0
+            for packet in video_stream.encode(frame):
+                container.mux(packet)
+
+            time_base = sub_stream.time_base
+            assert time_base is not None
+            subtitle = SubtitleSet.create(
+                text=b"0,0,Default,,0,0,0,,Hello World",
+                start=0,
+                end=int(2 / time_base),
+                pts=0,
+            )
+            packet = sub_ctx.encode_subtitle(subtitle)
+            packet.stream = sub_stream
+            container.mux(packet)
+
+            for packet in video_stream.encode():
+                container.mux(packet)
+
+        output.seek(0)
+        with av.open(output) as container:
+            assert len(container.streams.subtitles) == 1
+
+    def test_subtitle_encode_mkv_srt(self) -> None:
+        """Test encoding SRT subtitles to MKV container."""
+        from av.subtitles.subtitle import SubtitleSet
+
+        minimal_header = b"[Script Info]\n"
+
+        output = io.BytesIO()
+        with av.open(output, "w", format="matroska") as container:
+            sub_stream = container.add_stream("srt")
+            sub_ctx = cast(SubtitleCodecContext, sub_stream.codec_context)
+            sub_ctx.subtitle_header = minimal_header
+
+            container.start_encoding()
+
+            time_base = sub_stream.time_base
+            assert time_base is not None
+            for text, start_sec, duration_sec in [
+                (b"0,0,Default,,0,0,0,,First subtitle", 0, 2),
+                (b"0,0,Default,,0,0,0,,Second subtitle", 2, 2),
+                (b"0,0,Default,,0,0,0,,Third subtitle", 4, 2),
+            ]:
+                subtitle = SubtitleSet.create(
+                    text=text,
+                    start=0,
+                    end=int(duration_sec / time_base),
+                    pts=int(start_sec / time_base),
+                )
+                packet = sub_ctx.encode_subtitle(subtitle)
+                packet.stream = sub_stream
+                container.mux(packet)
+
+        output.seek(0)
+        with av.open(output, mode="r") as input_container:
+            assert len(input_container.streams.subtitles) == 1
+            subs: list[AssSubtitle] = []
+            for packet in input_container.demux():
+                subs.extend(cast(list[AssSubtitle], packet.decode()))
+            assert len(subs) == 3
+            assert b"First subtitle" in subs[0].dialogue
+            assert b"Second subtitle" in subs[1].dialogue
+            assert b"Third subtitle" in subs[2].dialogue


### PR DESCRIPTION
Fixes #196

subtitle_header is needed for creating subtitle codec context.
Rest is for encoding subtitle data. Not so sure about the API tbh.

Added tests + tested manually by adding subtitle tracks to some actual videos.