### PR TITLE
Enable libmp3lame for MP3 audio encoding

### DIFF
--- a/scripts/build-deps
+++ b/scripts/build-deps
@@ -62,6 +62,7 @@ echo ./configure
     --enable-gpl \
     --enable-version3 \
     --enable-libx264 \
+    --enable-libmp3lame \
     --enable-shared \
     --enable-sse \
     --enable-avx \


### PR DESCRIPTION
## Summary

Add `--enable-libmp3lame` flag to FFmpeg configure options in `scripts/build-deps` to enable MP3 audio encoding support.

## Changes

- Add `--enable-libmp3lame` to FFmpeg configure flags in `scripts/build-deps`

## Motivation

Currently, PyAV built with the default configuration cannot encode audio to MP3 format. Users who need to create MP3 files encounter codec errors because libmp3lame is not enabled during the FFmpeg build.

This is a commonly requested feature for audio processing workflows, such as:
- Converting audio files to MP3 format
- TTS (Text-to-Speech) applications that output MP3
- Audio streaming applications

## Build Dependency

Build environments need to have libmp3lame development package installed:
- Ubuntu/Debian: `apt install libmp3lame-dev`
- CentOS/RHEL/Fedora: `dnf install lame-devel`
- macOS: `brew install lame`

## Testing

After building with this change, MP3 encoding can be verified:

```python
import av

# Check encoder availability
codec = av.codec.Codec('libmp3lame', 'w')
print(f'Encoder: {codec.name}')  # Output: libmp3lame

# Encode to MP3
output = av.open('test.mp3', 'w')
stream = output.add_stream('libmp3lame', rate=44100)
stream.bit_rate = 128000
# ... encode audio frames ...
```