### PR TITLE
Add CodecContext global_quality property binding

### DIFF
--- a/av/video/codeccontext.pyi
+++ b/av/video/codeccontext.pyi
@@ -29,6 +29,7 @@ class VideoCodecContext(CodecContext):
     qmin: int
     qmax: int
     type: Literal["video"]
+    global_quality: int
 
     def encode(self, frame: VideoFrame | None = None) -> list[Packet]: ...
     def encode_lazy(self, frame: VideoFrame | None = None) -> Iterator[Packet]: ...

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -368,3 +368,21 @@ cdef class VideoCodecContext(CodecContext):
     @qmax.setter
     def qmax(self, value):
         self.ptr.qmax = value
+
+    @property
+    def global_quality(self):
+        """
+        Global quality for codecs which cannot change it per frame.
+        For example Intel QSV encoders like hevc_qsv.
+
+        Wraps :ffmpeg:`AVCodecContext.global_quality`.
+
+        :type: int
+        """
+        FF_QP2LAMBDA = 118 # from avutil.h
+        return int(self.ptr.global_quality / FF_QP2LAMBDA)
+
+    @global_quality.setter
+    def global_quality(self, value):
+        FF_QP2LAMBDA = 118 # from avutil.h
+        self.ptr.global_quality = int(value * FF_QP2LAMBDA)


### PR DESCRIPTION
Was trying to use QSV encoders but noticed that the property they use for quality-based mode is unavailable. This PR exposes it in PyAV.

Couldn't think of a useful test for this as QSV wouldn't be available in CI and i'm not aware of another video encoder that uses this (tested with libx264 but it's ignored).

Reference:
* https://ffmpeg.org/doxygen/0.8/structAVCodecContext.html#209f5ec60cb5f0b0a4962f4c5c5bb541
* https://ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
* https://trac.ffmpeg.org/wiki/Hardware/QuickSync
* https://github.com/mltframework/mlt/blob/c5534c8fa856940a397a1fe84d5ef3110d35ec43/src/modules/avformat/consumer_avformat.c#L1032

Example
```
import av
import av.datasets

input_container = av.open(av.datasets.curated("pexels/time-lapse-video-of-night-sky-857195.mp4"))
output_container = av.open("hevc_qsv_encoded.mp4", "w", options={})

input_stream = input_container.streams.video[0]
output_stream = output_container.add_stream('hevc_qsv', input_stream.average_rate)
output_stream.width = input_stream.width
output_stream.height = input_stream.height

output_stream.pix_fmt = "nv12"
output_stream.codec_context.global_quality = 20
output_stream.codec_context.qscale = True

for frame in input_container.decode(video=0):
    packet = output_stream.encode(frame)
    if packet: output_container.mux(packet)

input_container.close()
output_container.close()
```