### PR TITLE
Use zero-copy for Packet init from buffer data

### DIFF
--- a/av/opaque.pxd
+++ b/av/opaque.pxd
@@ -1,4 +1,8 @@
 cimport libav as lib
+from libc.stdint cimport uint8_t
+
+
+cdef void noop_free(void *opaque, uint8_t *data) noexcept nogil
 
 
 cdef class OpaqueContainer:

--- a/av/opaque.pyx
+++ b/av/opaque.pyx
@@ -3,6 +3,10 @@ from libc.stdint cimport uint8_t, uintptr_t
 from libc.string cimport memcpy
 
 
+cdef void noop_free(void *opaque, uint8_t *data) noexcept nogil:
+    pass
+
+
 cdef void key_free(void *opaque, uint8_t *data) noexcept nogil:
     cdef char *name = <char *>data
     with gil:


### PR DESCRIPTION
Instead of allocating new memory and copying data when creating a Packet from a buffer (bytes, numpy array, etc.), reference the source buffer directly using av_buffer_create with a noop_free callback. The ByteSource is stored in self.source to keep the Python buffer alive.