### PR TITLE
Make av.ArgumentError a subclass of ValueError

### DIFF
--- a/av/error.py
+++ b/av/error.py
@@ -290,7 +290,7 @@ _extend_builtin("OverflowError", (errno.ERANGE,))
 _extend_builtin("OSError", [code for code in errno.errorcode if code not in classes])
 
 
-class ArgumentError(FFmpegError):
+class ArgumentError(FFmpegError, ValueError):
     def __str__(self):
         msg = ""
         if self.strerror is not None:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -28,6 +28,8 @@ def test_stringify() -> None:
 
 def test_bases() -> None:
     assert issubclass(av.ArgumentError, av.FFmpegError)
+    # Deprecated, assert false for Major 18.0:
+    assert issubclass(av.ArgumentError, ValueError)
     assert issubclass(av.FileNotFoundError, FileNotFoundError)
     assert issubclass(av.FileNotFoundError, OSError)
     assert issubclass(av.FileNotFoundError, av.FFmpegError)


### PR DESCRIPTION
Make av.ArgumentError a subclass of ValueError until the next major version (18.0).