### PR TITLE
Fix setuptools warning about av.filter package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dynamic = ["version"]
 [tool.setuptools]
 zip-safe = false
 
+[tool.setuptools.packages.find]
+include = ["av*"]
+
 [tool.setuptools.dynamic]
 version = {attr = "av.about.__version__"}
 


### PR DESCRIPTION
Add explicit package discovery configuration to pyproject.toml to align with setup.py's find_packages() call, preventing the "Package 'av.filter' is absent from the packages configuration" warning during pip builds.