### PR TITLE
Fix: segfault when av_get_media_type_string returns NULL

### DIFF
--- a/av/stream.py
+++ b/av/stream.py
@@ -275,7 +275,10 @@ class Stream:
 
         :type: Literal["audio", "video", "subtitle", "data", "attachment"]
         """
-        return lib.av_get_media_type_string(self.ptr.codecpar.codec_type)
+        media_type = lib.av_get_media_type_string(self.ptr.codecpar.codec_type)
+        if media_type is cython.NULL:
+            return ""
+        return media_type
 
 
 @cython.cclass

--- a/av/stream.pyi
+++ b/av/stream.pyi
@@ -48,7 +48,7 @@ class Stream:
     disposition: Disposition
     frames: int
     language: str | None
-    type: Literal["video", "audio", "data", "subtitle", "attachment"]
+    type: Literal["video", "audio", "data", "subtitle", "attachment", ""]
 
     # From context
     codec_tag: str


### PR DESCRIPTION
Resolves: #2161.
- Adds `NULL` check for function return.
- Updates function signature in `.pyi` file.

*Btw: An empty string is returned when the function returns `NULL` in the fix. I'm not quite sure about that. Maybe an "unknown" is preferred?*