### PR TITLE
Fix resolution in generate video example

### DIFF
--- a/examples/numpy/generate_video.py
+++ b/examples/numpy/generate_video.py
@@ -14,7 +14,7 @@ stream.height = 320
 stream.pix_fmt = "yuv420p"
 
 for frame_i in range(total_frames):
-    img = np.empty((480, 320, 3))
+    img = np.empty((320, 480, 3))
     img[:, :, 0] = 0.5 + 0.5 * np.sin(2 * np.pi * (0 / 3 + frame_i / total_frames))
     img[:, :, 1] = 0.5 + 0.5 * np.sin(2 * np.pi * (1 / 3 + frame_i / total_frames))
     img[:, :, 2] = 0.5 + 0.5 * np.sin(2 * np.pi * (2 / 3 + frame_i / total_frames))


### PR DESCRIPTION
The [generate video example](https://github.com/PyAV-Org/PyAV/blob/main/examples/numpy/generate_video.py) contains the following lines of code

```python
stream.width = 480
stream.height = 320
...
img = np.empty((480, 320, 3))
...
frame = av.VideoFrame.from_ndarray(img, format="rgb24")
```

The typical convention is that the array shape's first dimension corresponds to the number of rows (height).
The resulting `frame` object has `frame.width = 320` and `frame.height = 480`.

The array should be defined as
```python
img = np.empty((height, width, 3))
```