### PR TITLE
Reduce overhead of `to_ndarray`

### DIFF
--- a/av/video/frame.py
+++ b/av/video/frame.py
@@ -266,7 +266,7 @@ supported_np_pix_fmts = {
 
 # Mapping from format name to (itemsize, dtype) for formats where planes
 # are simply concatenated into shape (height, width, channels).
-_np_pix_fmt_dtypes: dict[str, tuple[int, str]] = {
+_np_pix_fmt_dtypes: dict[str, tuple[cython.uint, str]] = {
     "abgr": (4, "uint8"),
     "argb": (4, "uint8"),
     "bayer_bggr8": (1, "uint8"),
@@ -716,13 +716,14 @@ class VideoFrame(Frame):
         # check size
         format_name = frame.format.name
         height, width = frame.ptr.height, frame.ptr.width
-        planes = frame.planes
+        planes: tuple[VideoPlane, ...] = frame.planes
         if format_name in {"yuv420p", "yuvj420p", "yuyv422", "yuv422p10le", "yuv422p"}:
             assert width % 2 == 0, "the width has to be even for this pixel format"
             assert height % 2 == 0, "the height has to be even for this pixel format"
 
         # cases planes are simply concatenated in shape (height, width, channels)
         if format_name in _np_pix_fmt_dtypes:
+            itemsize: cython.uint
             itemsize, dtype = _np_pix_fmt_dtypes[format_name]
             if len(planes) == 1:  # shortcut, avoid memory copy
                 array = useful_array(planes[0], itemsize, dtype).reshape(


### PR DESCRIPTION
#1725 refactored `to_ndarray` to use a `dict` for handling the different format cases. This introduced quite a bit of Python overhead since the dict needs to be constructed in every function call and can't be optimised by Cython. 

- 2caf056cf2b873097f18653ba981a87533176036 moves the formatting mapping out of the function call such that it isn't constructed every time
- ea8b07578f75d2ae8c358678893973d9565e696c slightly reduces the Python overhead by making sure that more calls can stay in C
- 5c6f10da08b5aed26e41028e39902062321b60a5 removes unneeded numpy array copies

I measured performance with a very simple benchmark which shows a 28% speedup
```python
import numpy as np
import av

array = np.random.randint(0, 256, size=(480, 640, 3), dtype=np.uint8)
frame = av.VideoFrame.from_ndarray(array, format="rgb24")
np.testing.assert_array_equal(frame.to_ndarray(), array)

%timeit frame.to_ndarray()
```
```
main:      4.18 μs ± 9.18 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
This PR: 3.01 μs ± 9.84 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

This PR is best to be reviewed commit by commit