### PR TITLE
Add ColorTrc, ColorPrimaries, etc., closes #1968

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Features:
 - Expose AVIndexEntry by :gh-user:`Queuecumber` in (:pr:`2136`).
 - Preserving hardware memory during cuvid decoding, exporting/importing via dlpack by :gh-user:`WyattBlue` in (:pr:`2155`).
 - Add enumerate_input_devices and enumerate_output_devices API by :gh-user:`WyattBlue` in (:pr:`2174`).
+- Add ``ColorTrc`` and ``ColorPrimaries`` enums; add ``color_trc`` and ``color_primaries`` properties to ``VideoFrame``; add ``dst_color_trc`` and ``dst_color_primaries`` parameters to ``VideoFrame.reformat()``, addressing :issue:`1968` by :gh-user:`WyattBlue` in (:pr:`2175`).
 
 Fixes:
 

--- a/av/video/frame.py
+++ b/av/video/frame.py
@@ -595,6 +595,32 @@ class VideoFrame(Frame):
     def color_range(self, value):
         self.ptr.color_range = value
 
+    @property
+    def color_trc(self):
+        """Transfer characteristic of frame.
+
+        Wraps :ffmpeg:`AVFrame.color_trc`.
+
+        """
+        return self.ptr.color_trc
+
+    @color_trc.setter
+    def color_trc(self, value):
+        self.ptr.color_trc = value
+
+    @property
+    def color_primaries(self):
+        """Color primaries of frame.
+
+        Wraps :ffmpeg:`AVFrame.color_primaries`.
+
+        """
+        return self.ptr.color_primaries
+
+    @color_primaries.setter
+    def color_primaries(self, value):
+        self.ptr.color_primaries = value
+
     def reformat(self, *args, **kwargs):
         """reformat(width=None, height=None, format=None, src_colorspace=None, dst_colorspace=None, interpolation=None)
 

--- a/av/video/frame.pyi
+++ b/av/video/frame.pyi
@@ -8,6 +8,7 @@ from av.frame import Frame
 
 from .format import VideoFormat
 from .plane import VideoPlane
+from .reformatter import ColorPrimaries, ColorTrc
 
 _SupportedNDarray = Union[
     np.ndarray[Any, np.dtype[np.uint8]],
@@ -41,6 +42,8 @@ class VideoFrame(Frame):
     pict_type: int
     colorspace: int
     color_range: int
+    color_trc: int
+    color_primaries: int
 
     @property
     def time(self) -> float: ...
@@ -65,6 +68,8 @@ class VideoFrame(Frame):
         interpolation: int | str | None = None,
         src_color_range: int | str | None = None,
         dst_color_range: int | str | None = None,
+        dst_color_trc: int | ColorTrc | None = None,
+        dst_color_primaries: int | ColorPrimaries | None = None,
     ) -> VideoFrame: ...
     def to_rgb(self, **kwargs: Any) -> VideoFrame: ...
     def save(self, filepath: str | Path) -> None: ...

--- a/av/video/reformatter.pxd
+++ b/av/video/reformatter.pxd
@@ -79,4 +79,6 @@ cdef class VideoReformatter:
                    lib.AVPixelFormat format, int src_colorspace,
                    int dst_colorspace, int interpolation,
                    int src_color_range, int dst_color_range,
-                   bint set_dst_colorspace, bint set_dst_color_range)
+                   bint set_dst_colorspace, bint set_dst_color_range,
+                   int dst_color_trc, int dst_color_primaries,
+                   bint set_dst_color_trc, bint set_dst_color_primaries)

--- a/av/video/reformatter.pyi
+++ b/av/video/reformatter.pyi
@@ -38,6 +38,39 @@ class ColorRange(IntEnum):
     JPEG = 2
     NB = 3
 
+class ColorTrc(IntEnum):
+    BT709 = cast(int, ...)
+    UNSPECIFIED = cast(int, ...)
+    GAMMA22 = cast(int, ...)
+    GAMMA28 = cast(int, ...)
+    SMPTE170M = cast(int, ...)
+    SMPTE240M = cast(int, ...)
+    LINEAR = cast(int, ...)
+    LOG = cast(int, ...)
+    LOG_SQRT = cast(int, ...)
+    IEC61966_2_4 = cast(int, ...)
+    BT1361_ECG = cast(int, ...)
+    IEC61966_2_1 = cast(int, ...)
+    BT2020_10 = cast(int, ...)
+    BT2020_12 = cast(int, ...)
+    SMPTE2084 = cast(int, ...)
+    SMPTE428 = cast(int, ...)
+    ARIB_STD_B67 = cast(int, ...)
+
+class ColorPrimaries(IntEnum):
+    BT709 = cast(int, ...)
+    UNSPECIFIED = cast(int, ...)
+    BT470M = cast(int, ...)
+    BT470BG = cast(int, ...)
+    SMPTE170M = cast(int, ...)
+    SMPTE240M = cast(int, ...)
+    FILM = cast(int, ...)
+    BT2020 = cast(int, ...)
+    SMPTE428 = cast(int, ...)
+    SMPTE431 = cast(int, ...)
+    SMPTE432 = cast(int, ...)
+    EBU3213 = cast(int, ...)
+
 class VideoReformatter:
     def reformat(
         self,
@@ -50,4 +83,6 @@ class VideoReformatter:
         interpolation: int | str | None = None,
         src_color_range: int | str | None = None,
         dst_color_range: int | str | None = None,
+        dst_color_trc: int | ColorTrc | None = None,
+        dst_color_primaries: int | ColorPrimaries | None = None,
     ) -> VideoFrame: ...

--- a/include/avutil.pxd
+++ b/include/avutil.pxd
@@ -53,10 +53,8 @@ cdef extern from "libavutil/avutil.h" nogil:
         AVCOL_RANGE_NB
 
     cdef enum AVColorPrimaries:
-        AVCOL_PRI_RESERVED0
         AVCOL_PRI_BT709
         AVCOL_PRI_UNSPECIFIED
-        AVCOL_PRI_RESERVED
         AVCOL_PRI_BT470M
         AVCOL_PRI_BT470BG
         AVCOL_PRI_SMPTE170M
@@ -69,10 +67,27 @@ cdef extern from "libavutil/avutil.h" nogil:
         AVCOL_PRI_SMPTE432
         AVCOL_PRI_EBU3213
         AVCOL_PRI_JEDEC_P22
-        AVCOL_PRI_NB
 
     cdef enum AVColorTransferCharacteristic:
-        pass
+        AVCOL_TRC_BT709
+        AVCOL_TRC_UNSPECIFIED
+        AVCOL_TRC_GAMMA22
+        AVCOL_TRC_GAMMA28
+        AVCOL_TRC_SMPTE170M
+        AVCOL_TRC_SMPTE240M
+        AVCOL_TRC_LINEAR
+        AVCOL_TRC_LOG
+        AVCOL_TRC_LOG_SQRT
+        AVCOL_TRC_IEC61966_2_4
+        AVCOL_TRC_BT1361_ECG
+        AVCOL_TRC_IEC61966_2_1
+        AVCOL_TRC_BT2020_10
+        AVCOL_TRC_BT2020_12
+        AVCOL_TRC_SMPTE2084
+        AVCOL_TRC_SMPTEST2084
+        AVCOL_TRC_SMPTE428
+        AVCOL_TRC_SMPTEST428_1
+        AVCOL_TRC_ARIB_STD_B67
 
     cdef void* av_malloc(size_t size)
     cdef void* av_mallocz(size_t size)

--- a/tests/test_colorspace.py
+++ b/tests/test_colorspace.py
@@ -1,5 +1,10 @@
 import av
-from av.video.reformatter import ColorRange, Colorspace
+from av.video.reformatter import (
+    ColorPrimaries,
+    ColorRange,
+    Colorspace,
+    ColorTrc,
+)
 
 from .common import fate_suite
 
@@ -38,3 +43,61 @@ def test_sky_timelapse() -> None:
     assert stream.codec_context.color_primaries == 1
     assert stream.codec_context.color_trc == 1
     assert stream.codec_context.colorspace == 1
+
+
+def test_frame_color_trc_property() -> None:
+    frame = av.VideoFrame(width=64, height=64, format="rgb24")
+    assert frame.color_trc == ColorTrc.UNSPECIFIED
+
+    frame.color_trc = ColorTrc.IEC61966_2_4
+    assert frame.color_trc == ColorTrc.IEC61966_2_4
+
+    frame.color_trc = ColorTrc.BT709
+    assert frame.color_trc == ColorTrc.BT709
+
+
+def test_frame_color_primaries_property() -> None:
+    frame = av.VideoFrame(width=64, height=64, format="rgb24")
+    assert frame.color_primaries == ColorPrimaries.UNSPECIFIED
+
+    frame.color_primaries = ColorPrimaries.BT709
+    assert frame.color_primaries == ColorPrimaries.BT709
+    assert frame.color_primaries == 1  # AVCOL_PRI_BT709
+
+
+def test_reformat_dst_color_trc() -> None:
+    # Reformat a frame and tag it with sRGB transfer characteristic.
+    frame = av.VideoFrame(width=64, height=64, format="yuv420p")
+    rgb = frame.reformat(
+        format="rgb24",
+        dst_colorspace=Colorspace.ITU709,
+        dst_color_trc=ColorTrc.IEC61966_2_4,
+    )
+    assert rgb.format.name == "rgb24"
+    assert rgb.colorspace == Colorspace.ITU709
+    assert rgb.color_trc == ColorTrc.IEC61966_2_4
+
+
+def test_reformat_dst_color_primaries() -> None:
+    frame = av.VideoFrame(width=64, height=64, format="yuv420p")
+    rgb = frame.reformat(
+        format="rgb24",
+        dst_color_primaries=ColorPrimaries.BT709,
+    )
+    assert rgb.color_primaries == ColorPrimaries.BT709
+
+
+def test_reformat_preserves_color_trc() -> None:
+    # When dst_color_trc is not specified, the source frame's value is preserved.
+    frame = av.VideoFrame(width=64, height=64, format="yuv420p")
+    frame.color_trc = ColorTrc.BT709
+    rgb = frame.reformat(format="rgb24")
+    assert rgb.color_trc == ColorTrc.BT709
+
+
+def test_reformat_preserves_color_primaries() -> None:
+    # When dst_color_primaries is not specified, the source frame's value is preserved.
+    frame = av.VideoFrame(width=64, height=64, format="yuv420p")
+    frame.color_primaries = ColorPrimaries.BT709
+    rgb = frame.reformat(format="rgb24")
+    assert rgb.color_primaries == ColorPrimaries.BT709


### PR DESCRIPTION
- Add ColorTrc and ColorPrimaries IntEnum classes to av.video.reformatter
- Add color_trc and color_primaries as read/write properties on VideoFrame
- Add dst_color_trc and dst_color_primaries parameters to `VideoFrame.reformat()`