### PR TITLE
Add missing `SWS_SPLINE` interpolation

### DIFF
--- a/av/video/reformatter.py
+++ b/av/video/reformatter.py
@@ -17,7 +17,7 @@ class Interpolation(IntEnum):
     BICUBLIN: "Luma bicubic / chroma bilinear" = SWS_BICUBLIN
     GAUSS: "Gaussian" = SWS_GAUSS
     SINC: "Sinc" = SWS_SINC
-    LANCZOS: "Lanczos" = SWS_LANCZOS
+    LANCZOS: "3-tap sinc/sinc" = SWS_LANCZOS
     SPLINE: "Cubic Keys spline" = SWS_SPLINE
 
 


### PR DESCRIPTION
This is already part of the typehints, but wasn't implemented https://github.com/PyAV-Org/PyAV/blob/4baa626fe940e4aa019f17411beb009942ad7f3d/av/video/reformatter.pyi#L17