### PR TITLE
Prevent data copy in `VideoFrame.to_ndarray()` for padded frames

### DIFF
--- a/av/video/frame.py
+++ b/av/video/frame.py
@@ -539,6 +539,8 @@ class VideoFrame(Frame):
         plane_count: cython.int = 0
         while plane_count < max_plane_count and self.ptr.extended_data[plane_count]:
             plane_count += 1
+        if plane_count == 1:
+            return (VideoPlane(self, 0),)
         return tuple([VideoPlane(self, i) for i in range(plane_count)])
 
     @property

--- a/av/video/plane.py
+++ b/av/video/plane.py
@@ -26,7 +26,7 @@ class VideoPlane(Plane):
                 frames_ctx.sw_format, frame.ptr.width, frame.ptr.height
             )
 
-        if fmt.name == "pal8" and index == 1:
+        if index == 1 and fmt.name == "pal8":
             self.width = 256
             self.height = 1
             self.buffer_size = 256 * 4


### PR DESCRIPTION
Calling `VideoFrame.to_ndarray()` on unaligned video frames is very slow since the frame is copied.

This PR prevents the copy for padded frames by using strided views into the frame data.

When benchmarked with the following code I'm seeing a huge speedup for padded frames. Which now has the same performance characteristics as the aligned case

```python
import timeit
import numpy as np
import av

aligned = av.VideoFrame(1920, 1080, format="rgb24")
padded = av.VideoFrame(1080, 1920, format="rgb24")
aligned_yuv = av.VideoFrame(1920, 1080, format="yuv420p")
padded_yuv = av.VideoFrame(1080, 1920, format="yuv420p")

n = 1000
t_aligned = timeit.repeat(lambda: aligned.to_ndarray(), repeat=5, number=n)
t_padded = timeit.repeat(lambda: padded.to_ndarray(), repeat=5, number=n)
t_aligned_yuv = timeit.repeat(lambda: aligned_yuv.to_ndarray(format="rgb24"), repeat=5, number=n)
t_padded_yuv = timeit.repeat(lambda: padded_yuv.to_ndarray(format="rgb24"), repeat=5, number=n)

t_aligned = np.array(t_aligned) / n
t_padded = np.array(t_padded) / n
t_aligned_yuv = np.array(t_aligned_yuv) / n
t_padded_yuv = np.array(t_padded_yuv) / n

print(f"Aligned (1920x1080 rgb24):   {t_aligned.mean() * 1e6:.2f} ± {t_aligned.std() * 1e6:.2f} µs")
print(f"Padded  (1080x1920 rgb24):   {t_padded.mean() * 1e6:.2f} ± {t_padded.std() * 1e6:.2f} µs")
print(f"Aligned (1920x1080 yuv420p): {t_aligned_yuv.mean() * 1e6:.2f} ± {t_aligned_yuv.std() * 1e6:.2f} µs")
print(f"Padded  (1080x1920 yuv420p): {t_padded_yuv.mean() * 1e6:.2f} ± {t_padded_yuv.std() * 1e6:.2f} µs")
```

**Before:**
```
Aligned (1920x1080 rgb24):   1.76 ± 0.02 µs
Padded  (1080x1920 rgb24):   148.09 ± 7.51 µs
Aligned (1920x1080 yuv420p): 364.42 ± 1.05 µs
Padded  (1080x1920 yuv420p): 522.63 ± 0.08 µs
```
**After:**
```
Aligned (1920x1080 rgb24):   1.73 ± 0.03 µs
Padded  (1080x1920 rgb24):   1.76 ± 0.04 µs
Aligned (1920x1080 yuv420p): 365.67 ± 0.83 µs
Padded  (1080x1920 yuv420p): 368.43 ± 0.86 µs
```

The main changes of this PR are in e2ad2fb28875893fd1a412d48891ec17bbfa4bc8.

b105f6e745b89568c50f1702827dcb7c0e0cd64e, cd5ffd0994b37069f14db0787b2b503e5dd4da5c, and 02ec746c425bff6fe36a6e774614d6d01654e570 are minor followup optimisations to ensure that this PR doesn't introduce a regression for the aligned case.