### PR TITLE
Only call reformat if necessary

### DIFF
--- a/av/video/frame.py
+++ b/av/video/frame.py
@@ -750,7 +750,7 @@ class VideoFrame(Frame):
                 frames_ctx.sw_format, self.ptr.width, self.ptr.height
             ).name
 
-        frame: VideoFrame = self.reformat(**kwargs)
+        frame: VideoFrame = self.reformat(**kwargs) if len(kwargs) > 0 else self
         if frame.ptr.hw_frames_ctx:
             raise ValueError("Cannot convert a hardware frame to numpy directly.")
 


### PR DESCRIPTION
This prevents the need for constructing a `VideoReformatter` for cases where `frame.to_ndarray()` is called without arguments:

```python
import av
import numpy as np
frame = av.VideoFrame(1920, 1080, format="rgb24")
%timeit frame.to_ndarray()
```

**Before:**
```
1.75 μs ± 10.4 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

**After:**
```
1.39 μs ± 2.76 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```