### PR TITLE
Fix TestPacketSideData.test_skip_samples_remux running against FFmpeg 8.1

### DIFF
--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -148,9 +148,10 @@ class TestPacketSideData:
                         sdata = pkt.get_sidedata("skip_samples")
                         raw = bytes(sdata)
                         skip_end = struct.unpack("<I", raw[4:8])[0]
-                        assert skip_end == 706
-                        sdata.update(raw[:4] + struct.pack("<I", 0) + raw[8:])
-                        pkt.set_sidedata(sdata)
+                        if skip_end > 0:
+                            assert skip_end == 706
+                            sdata.update(raw[:4] + struct.pack("<I", 0) + raw[8:])
+                            pkt.set_sidedata(sdata)
                     pkt.stream = out_stream
                     out.mux(pkt)
 


### PR DESCRIPTION
`TestPacketSideData.test_skip_samples_remux` fails when PyAV is built against FFmpeg 8.1 with the following error:
```
__________________ TestPacketSideData.test_skip_samples_remux __________________

self = <tests.test_packet.TestPacketSideData object at 0xffff6d11f5c0>

    def test_skip_samples_remux(self) -> None:
        # Source file has skip_end=706 on last packet. Setting to 0 should
        # result in 706 more decoded samples. And the file duration reported by
        # the container should also increase.
        output_path = sandboxed("skip_samples_modified.mkv")
    
        with av.open(fate_suite("mkv/codec_delay_opus.mkv")) as c:
            original_samples = sum(f.samples for f in c.decode(c.streams.audio[0]))
    
        with av.open(fate_suite("mkv/codec_delay_opus.mkv")) as inp:
            original_duration = inp.duration
            audio_stream = inp.streams.audio[0]
            with av.open(output_path, "w") as out:
                out_stream = out.add_stream_from_template(audio_stream)
                for pkt in inp.demux(audio_stream):
                    if pkt.dts is None:
                        continue
                    if pkt.has_sidedata("skip_samples"):
                        sdata = pkt.get_sidedata("skip_samples")
                        raw = bytes(sdata)
                        skip_end = struct.unpack("<I", raw[4:8])[0]
>                       assert skip_end == 706
E                       assert 0 == 706

../tests/test_packet.py:151: AssertionError
```

FFmpeg 8.1 changed behavior for Opus demuxing, skip_samples side data is now attached to two packets
- the first packet carries a skip_start=312 (Opus codec pre-skip delay) with skip_end=0
- the last packet carries the gapless end trim (skip_start=0, skip_end=706)

Previously, only the last packet received this side data. This PR guards the assertion and modification with if skip_end > 0, so packets with only a skip_start value are passed through unmodified.

Ref: https://git.ffmpeg.org/gitweb/ffmpeg.git/blobdiff/1dd85471937075a2bcdbfc0fa387461e20f89574..0880458e4c27337718ca836e1193803a089fc690:/libavformat/matroskadec.c