### PR TITLE
Fix changed rounding in in NEON-accelerated yuv420p->rgb24 in FFmpeg 8.1

### DIFF
--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -1293,4 +1293,6 @@ def test_reformat_pixel_format_align() -> None:
         expected_rgb[:, :, 2] = 255
 
         frame_rgb = frame_yuv.reformat(format="rgb24")
-        assertNdarraysEqual(frame_rgb.to_ndarray(), expected_rgb)
+        result = frame_rgb.to_ndarray()
+        assert result.shape == expected_rgb.shape
+        assert numpy.abs(result.astype(int) - expected_rgb.astype(int)).max() <= 1


### PR DESCRIPTION
FFmpeg 8.1 introduced a 4.3x speedup for yuv420p->rgb24 through NEON acceleration on aarch64. This results in a change in rounding behaviour in `test_reformat_pixel_format_align` causing the following failure:
```
_______________________ test_reformat_pixel_format_align _______________________

    def test_reformat_pixel_format_align() -> None:
        height = 480
        for width in range(2, 258, 2):
            frame_yuv = VideoFrame(width, height, "yuv420p")
            for plane in frame_yuv.planes:
                plane.update(b"\xff" * plane.buffer_size)
    
            expected_rgb = numpy.zeros(shape=(height, width, 3), dtype=numpy.uint8)
            expected_rgb[:, :, 0] = 255
            expected_rgb[:, :, 1] = 124
            expected_rgb[:, :, 2] = 255
    
            frame_rgb = frame_yuv.reformat(format="rgb24")
>           assertNdarraysEqual(frame_rgb.to_ndarray(), expected_rgb)

../tests/test_videoframe.py:1296: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

a = array([[[255, 125, 255],
        [255, 125, 255],
        [255, 125, 255],
        ...,
        [255, 125, 255],
     ...     ...,
        [255, 125, 255],
        [255, 125, 255],
        [255, 125, 255]]], shape=(480, 16, 3), dtype=uint8)
b = array([[[255, 124, 255],
        [255, 124, 255],
        [255, 124, 255],
        ...,
        [255, 124, 255],
     ...     ...,
        [255, 124, 255],
        [255, 124, 255],
        [255, 124, 255]]], shape=(480, 16, 3), dtype=uint8)

    def assertNdarraysEqual(a: np.ndarray, b: np.ndarray) -> None:
        assert a.shape == b.shape
    
        comparison = a == b
        if not comparison.all():
            it = np.nditer(comparison, flags=["multi_index"])
            msg = ""
            for equal in it:
                if not equal:
                    msg += "- arrays differ at index {}; {} {}\n".format(
                        it.multi_index,
                        a[it.multi_index],
                        b[it.multi_index],
                    )
>           assert False, f"ndarrays contents differ\n{msg}"
                   ^^^^^
```

Commit ref: https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/7fab0becab09bf79a4dae61fdf9c9f05045fd457

This PR fixes the test by adding a ±1 tolerance, is this an acceptable approach here?