### PR TITLE
Remove `_send_packet_and_recv` to simplify `decode()`

### DIFF
--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -52,7 +52,6 @@ cdef class CodecContext:
     # send/recv buffer may be limited to a single frame. Ergo, we need to flush
     # the buffer as often as possible.
     cdef _recv_packet(self)
-    cdef _send_packet_and_recv(self, Packet packet)
     cdef _recv_frame(self)
 
     cdef _transfer_hwframe(self, Frame frame)

--- a/av/codec/context.py
+++ b/av/codec/context.py
@@ -363,25 +363,6 @@ class CodecContext:
             packet = self._recv_packet()
 
     @cython.cfunc
-    def _send_packet_and_recv(self, packet: Packet | None):
-        frame: Frame
-        res: cython.int
-        with cython.nogil:
-            res = lib.avcodec_send_packet(
-                self.ptr, packet.ptr if packet is not None else cython.NULL
-            )
-        err_check(res, "avcodec_send_packet()")
-
-        out: list = []
-        while True:
-            frame = self._recv_frame()
-            if frame:
-                out.append(frame)
-            else:
-                break
-        return out
-
-    @cython.cfunc
     def _prepare_frames_for_encode(self, frame: Frame | None) -> list:
         return [frame]
 
@@ -487,12 +468,20 @@ class CodecContext:
 
         self.open(strict=False)
 
-        res: list = []
-        for frame in self._send_packet_and_recv(packet):
-            if isinstance(frame, Frame):
-                self._setup_decoded_frame(frame, packet)
-            res.append(frame)
-        return res
+        res: cython.int
+        with cython.nogil:
+            res = lib.avcodec_send_packet(
+                self.ptr, packet.ptr if packet is not None else cython.NULL
+            )
+        err_check(res, "avcodec_send_packet()")
+
+        out: list = []
+        frame = self._recv_frame()
+        while frame:
+            self._setup_decoded_frame(frame, packet)
+            out.append(frame)
+            frame = self._recv_frame()
+        return out
 
     @cython.ccall
     def flush_buffers(self):

--- a/av/subtitles/codeccontext.py
+++ b/av/subtitles/codeccontext.py
@@ -1,6 +1,7 @@
 import cython
 from cython.cimports import libav as lib
 from cython.cimports.av.buffer import ByteSource, bytesource
+from cython.cimports.av.codec.context import CodecContext
 from cython.cimports.av.error import err_check
 from cython.cimports.av.packet import Packet
 from cython.cimports.av.subtitles.subtitle import SubtitleProxy, SubtitleSet
@@ -103,11 +104,17 @@ class SubtitleCodecContext(CodecContext):
 
         return packet
 
-    @cython.cfunc
-    def _send_packet_and_recv(self, packet: Packet | None):
+    @cython.ccall
+    def decode(self, packet: Packet | None = None):
+        """Decode a subtitle packet, returning a list of :class:`.Subtitle` objects
+        if a subtitle was decoded, or an empty list otherwise."""
+        if not self.codec.ptr:
+            raise ValueError("cannot decode unknown codec")
+
         if packet is None:
             raise RuntimeError("packet cannot be None")
 
+        self.open(strict=False)
         proxy: SubtitleProxy = SubtitleProxy()
         got_frame: cython.int = 0
 
@@ -121,7 +128,7 @@ class SubtitleCodecContext(CodecContext):
         )
 
         if got_frame:
-            return SubtitleSet(proxy)
+            return list(SubtitleSet(proxy))
         return []
 
     @cython.ccall


### PR DESCRIPTION
`_send_packet_and_recv` currently creates an extra `list`. This PR inlines the code into `decode()` to prevent the list creation which also simplifies the code a bit.