### PR TITLE
Use `layout_compare()` for `AudioLayout.__eq__()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,13 +31,16 @@ v17.0.1 (next)
 Fixes:
 
 - A cdivision decorator for faster division.
+- Adjust tests so they work with 8.1 by :gh-user:`strophy`.
 - Make VideoFormat.components lazy by :gh-user:`WyattBlue`.
 - Break reference cycle ``StreamContainer.get()`` by :gh-user:`lgeiger`.
 - Expose threads in filter graph by :gh-user:`lgeiger`.
 - Fix crash with container closing with GC by :gh-user:`WyattBlue`.
-- Fix regression in 17.0.0 :issue:`2223`.
+- Fix "Writing packets to data stream broken in av>=17" regression :issue:`2223` by :gh-user:`WyattBlue`.
 - Remove ``_send_packet_and_recv`` to simplify ``decode()`` by :gh-user:`lgeiger`.
 - Reuse a ``AVPacket`` read buffer when demuxing by :gh-user:`lgeiger` and :gh-user:`WyattBlue`.
+- Use ``AVCodecContext.frame_num`` instead of counting ourselves by :gh-user:`WyattBlue`.
+- Use ``av_channel_layout_compare()`` for ``AudioLayout.__eq__()`` by :gh-user:`WyattBlue`.
 
 v17.0.0
 -------

--- a/av/audio/layout.py
+++ b/av/audio/layout.py
@@ -48,10 +48,14 @@ class AudioLayout:
         return f"<av.{self.__class__.__name__} {self.name!r}>"
 
     def __eq__(self, other):
+        if not isinstance(other, AudioLayout):
+            return False
+        c_other: lib.AVChannelLayout = cython.cast(AudioLayout, other).layout
         return (
-            isinstance(other, AudioLayout)
-            and self.name == other.name
-            and self.nb_channels == other.nb_channels
+            lib.av_channel_layout_compare(
+                cython.address(self.layout), cython.address(c_other)
+            )
+            == 0
         )
 
     @property

--- a/av/video/codeccontext.pxd
+++ b/av/video/codeccontext.pxd
@@ -18,5 +18,4 @@ cdef struct AVCodecPrivateData:
 cdef class VideoCodecContext(CodecContext):
     cdef AVCodecPrivateData _private_data
     cdef readonly VideoReformatter reformatter
-    cdef readonly int encoded_frame_count
     cdef VideoFrame next_frame

--- a/av/video/codeccontext.py
+++ b/av/video/codeccontext.py
@@ -72,15 +72,12 @@ class VideoCodecContext(CodecContext):
                 # is_hwaccel() function on each stream's codec context.
                 self.hwaccel_ctx = None
 
-        self.encoded_frame_count = 0
-
     @cython.cfunc
     def _prepare_frames_for_encode(self, input: Frame | None) -> list:
         if input is None or not input:
             return [None]
 
         vframe: VideoFrame = input
-        # Reformat if it doesn't match.
         if (
             vframe.format.pix_fmt != self.pix_fmt
             or vframe.width != self.ptr.width
@@ -97,11 +94,9 @@ class VideoCodecContext(CodecContext):
                 threads=self.ptr.thread_count,
             )
 
-        # There is no pts, so create one.
         if vframe.ptr.pts == lib.AV_NOPTS_VALUE:
-            vframe.ptr.pts = cython.cast(int64_t, self.encoded_frame_count)
+            vframe.ptr.pts = self.ptr.frame_num
 
-        self.encoded_frame_count += 1
         return [vframe]
 
     @cython.cfunc

--- a/include/avcodec.pxd
+++ b/include/avcodec.pxd
@@ -1,31 +1,23 @@
 from libc.stdint cimport int64_t, uint8_t, uint16_t, uint32_t, uint64_t
 
 cdef extern from "libavutil/channel_layout.h" nogil:
-    ctypedef enum AVChannelOrder:
-        pass
     ctypedef enum AVChannel:
         AV_CHAN_NONE = -1
         AV_CHAN_FRONT_LEFT
         AV_CHAN_FRONT_RIGHT
         AV_CHAN_FRONT_CENTER
     ctypedef struct AVChannelLayout:
-        AVChannelOrder order
         int nb_channels
-        uint64_t mask
-        # union:
-        #     uint64_t mask
-        #     AVChannelCustom *map
-        void *opaque
 
     int av_channel_layout_default(AVChannelLayout *ch_layout, int nb_channels)
     int av_channel_layout_from_string(AVChannelLayout *channel_layout, const char *str)
     int av_channel_layout_describe(const AVChannelLayout *channel_layout, char *buf, size_t buf_size)
     int av_channel_name(char *buf, size_t buf_size, AVChannel channel_id)
     int av_channel_description(char *buf, size_t buf_size, AVChannel channel_id)
+    int av_channel_layout_compare(AVChannelLayout *chl, AVChannelLayout *chl1)
     AVChannel av_channel_layout_channel_from_index(AVChannelLayout *channel_layout, unsigned int idx)
 
 cdef extern from "libavcodec/avcodec.h" nogil:
-    cdef set pyav_get_available_codecs()
     cdef int avcodec_version()
     cdef char* avcodec_configuration()
     cdef char* avcodec_license()
@@ -290,6 +282,7 @@ cdef extern from "libavcodec/avcodec.h" nogil:
 
         int subtitle_header_size
         uint8_t *subtitle_header
+        int64_t frame_num
 
     cdef AVCodecContext* avcodec_alloc_context3(const AVCodec *codec)
     cdef void avcodec_free_context(AVCodecContext **ctx)


### PR DESCRIPTION
And use AVCodecContext.frame_num instead of keeping track ourselves.