### PR TITLE
Make Disposition an IntFlag so Stream.disposition setter accepts members

### DIFF
--- a/av/stream.py
+++ b/av/stream.py
@@ -1,4 +1,4 @@
-from enum import Flag
+from enum import IntFlag
 
 import cython
 from cython.cimports import libav as lib
@@ -12,7 +12,7 @@ from cython.cimports.av.utils import (
 )
 
 
-class Disposition(Flag):
+class Disposition(IntFlag):
     default = 1 << 0
     dub = 1 << 1
     original = 1 << 2

--- a/av/stream.pyi
+++ b/av/stream.pyi
@@ -1,4 +1,4 @@
-from enum import Flag
+from enum import IntFlag
 from fractions import Fraction
 from typing import Literal, cast
 
@@ -6,7 +6,7 @@ from .codec import Codec, CodecContext
 from .container import Container
 from .index import IndexEntries
 
-class Disposition(Flag):
+class Disposition(IntFlag):
     default = cast(int, ...)
     dub = cast(int, ...)
     original = cast(int, ...)


### PR DESCRIPTION
Closes #2256

`Stream.disposition` is typed as `Disposition` but the runtime setter (`self.ptr.disposition = value`, a C `int` field) calls `int(value)`, which fails on plain `Flag` members because they are not `int` subclasses. Switching `Disposition` to `IntFlag` fixes the contract: members are `int` subclasses, so the conversion succeeds, and bitwise / membership semantics are unchanged.

```python
# Before: TypeError
video.disposition = Disposition.attached_pic

# After: OK
video.disposition = Disposition.attached_pic
```

Both `av/stream.py` (runtime) and `av/stream.pyi` (stub) are updated for consistency.
