### PR TITLE
Fix subtitle UTF-8 handling

### DIFF
--- a/av/subtitles/subtitle.py
+++ b/av/subtitles/subtitle.py
@@ -297,7 +297,7 @@ class AssSubtitle(Subtitle):
         i: cython.Py_ssize_t = 0
         state: cython.bint = False
         ass_text: bytes = self.ass
-        char, next_char = cython.declare(cython.char)
+        char, next_char = cython.declare(cython.uchar)
         result: bytearray = bytearray()
         text_len: cython.Py_ssize_t = len(ass_text)
 

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -119,6 +119,16 @@ class TestSubtitleEncoding(TestCase):
         assert len(subtitle) == 1
         assert cast(AssSubtitle, subtitle[0]).ass == text
 
+    def test_subtitle_dialogue_extended_chars(self) -> None:
+        """Test handling of extended UTF-8 characters in subtitle dialogue."""
+        from av.subtitles.subtitle import SubtitleSet
+
+        text = "0,0,Default,,0,0,0,,♪ Hey, hey, hey ♪".encode("utf-8")
+        subtitle = SubtitleSet.create(text=text, start=0, end=2000, pts=0)
+        sub = cast(AssSubtitle, subtitle[0])
+
+        assert sub.dialogue == "♪ Hey, hey, hey ♪".encode("utf-8")
+
     def test_subtitle_encode_mp4(self) -> None:
         """Test encoding subtitles to MP4 container."""
         from av.subtitles.subtitle import SubtitleSet


### PR DESCRIPTION
Previously, certain UTF-8 strings caused runtime error in `AssSubtitles.dialogue` because bytes were interpreted as signed instead of unsigned

```
>   result.append(char)
    ^^^^^^^^^^^
E   ValueError: byte must be in range(0, 256)
```