### PR TITLE
Fix FFmpegError memory leak

### DIFF
--- a/av/error.py
+++ b/av/error.py
@@ -75,15 +75,15 @@ class FFmpegError(Exception):
     """
 
     def __init__(self, code, message, filename=None, log=None):
-        self.errno = code
-        self.strerror = message
-
         args = [code, message]
         if filename or log:
             args.append(filename)
             if log:
                 args.append(log)
         super().__init__(*args)
+
+        self.errno = code
+        self.strerror = message
         self.args = tuple(args)
 
     @property


### PR DESCRIPTION
It seems like setting `self.strerror` before calling `OSError.__init__` causes a reference leak. This PR fixes by moving the assignment after the init. This actually looks like a CPython bug, I'll investigate this tomorrow.

The memory leak can be reproduced with the following script:
```python
import gc
import resource

import av


def rss_kb() -> int:
    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss


def main():
    resampler = av.AudioResampler(format="s16", layout="stereo", rate=48000)

    for i in range(200000):
        frame = av.AudioFrame("s16", "stereo", 960)
        frame.sample_rate = 44100
        resampler.resample(frame)

        if i % 20000 == 0:
            gc.collect()
            print(f"iter {i:>7}: maxrss = {rss_kb()}")

    resampler.resample(None)
    gc.collect()
    print(f"final     : maxrss = {rss_kb()}")


if __name__ == "__main__":
    main()
```

**main:**
```
iter       0: maxrss = 42303488
iter   20000: maxrss = 43958272
iter   40000: maxrss = 45596672
iter   60000: maxrss = 47202304
iter   80000: maxrss = 48807936
iter  100000: maxrss = 50413568
iter  120000: maxrss = 52019200
iter  140000: maxrss = 53624832
iter  160000: maxrss = 55230464
iter  180000: maxrss = 56836096
final     : maxrss = 58458112
```

**This PR:**
```
iter       0: maxrss = 42565632
iter   20000: maxrss = 42631168
iter   40000: maxrss = 42663936
iter   60000: maxrss = 42663936
iter   80000: maxrss = 42663936
iter  100000: maxrss = 42663936
iter  120000: maxrss = 42663936
iter  140000: maxrss = 42663936
iter  160000: maxrss = 42663936
iter  180000: maxrss = 42663936
final     : maxrss = 42680320
```

Fixes #2282 