### PR TITLE
Fix memory leak in `AudioLayout` by uninitializing channel layout

### DIFF
--- a/av/audio/layout.py
+++ b/av/audio/layout.py
@@ -28,6 +28,9 @@ def get_audio_layout(c_layout: lib.AVChannelLayout) -> AudioLayout:
 @cython.final
 @cython.cclass
 class AudioLayout:
+    def __dealloc__(self):
+        lib.av_channel_layout_uninit(cython.address(self.layout))
+
     def __cinit__(self, layout):
         if layout is _cinit_bypass_sentinel:
             return

--- a/include/avcodec.pxd
+++ b/include/avcodec.pxd
@@ -16,6 +16,7 @@ cdef extern from "libavutil/channel_layout.h" nogil:
     int av_channel_description(char *buf, size_t buf_size, AVChannel channel_id)
     int av_channel_layout_compare(AVChannelLayout *chl, AVChannelLayout *chl1)
     AVChannel av_channel_layout_channel_from_index(AVChannelLayout *channel_layout, unsigned int idx)
+    void av_channel_layout_uninit(AVChannelLayout *channel_layout)
 
 cdef extern from "libavcodec/avcodec.h" nogil:
     cdef int avcodec_version()


### PR DESCRIPTION
This fixes a memory leak in `AudioLayout` caused by not freeing channel layout.

```python
import gc
import resource
import sys
from av import AudioLayout

def get_rss():
    ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
    return ru_maxrss / 1024 / 1024 if sys.platform == "darwin" else ru_maxrss / 1024

start_mem = get_rss()
for i in range(1000000):
    layout1 = AudioLayout("ambisonic 1")
    layout2 = AudioLayout("FC+FL")
gc.collect()
print(f"Memory difference: {get_rss() - start_mem:.2f} MB")
```
**main:** Memory difference: 60.70 MB
**This PR:** Memory difference: 0.00 MB

Found while investigating #2282