### PR TITLE
Break reference cycle between `FilterLink` and `Graph`

### DIFF
--- a/av/filter/link.pxd
+++ b/av/filter/link.pxd
@@ -7,7 +7,7 @@ from av.filter.link cimport FilterContextPad, FilterLink
 
 
 cdef class FilterLink:
-    cdef readonly Graph graph
+    cdef object _graph
     cdef lib.AVFilterLink *ptr
 
     cdef FilterContextPad _input

--- a/av/filter/link.py
+++ b/av/filter/link.py
@@ -1,3 +1,5 @@
+import weakref
+
 import cython
 import cython.cimports.libav as lib
 from cython.cimports.av.filter.graph import Graph
@@ -13,6 +15,13 @@ class FilterLink:
             raise RuntimeError("cannot instantiate FilterLink")
 
     @property
+    def graph(self) -> Graph:
+        if g := self._graph():
+            return g
+        else:
+            raise RuntimeError("graph is unallocated")
+
+    @property
     def input(self):
         if self._input:
             return self._input
@@ -23,7 +32,8 @@ class FilterLink:
                 break
         else:  # nobreak
             raise RuntimeError("could not find link in context")
-        ctx = self.graph._context_by_ptr[cython.cast(cython.long, cctx)]
+        graph: Graph = self.graph
+        ctx = graph._context_by_ptr[cython.cast(cython.long, cctx)]
         self._input = ctx.outputs[i]
         return self._input
 
@@ -39,7 +49,8 @@ class FilterLink:
         else:
             raise RuntimeError("could not find link in context")
         try:
-            ctx = self.graph._context_by_ptr[cython.cast(cython.long, cctx)]
+            graph: Graph = self.graph
+            ctx = graph._context_by_ptr[cython.cast(cython.long, cctx)]
         except KeyError:
             raise RuntimeError(
                 "could not find context in graph", (cctx.name, cctx.filter.name)
@@ -51,7 +62,7 @@ class FilterLink:
 @cython.cfunc
 def wrap_filter_link(graph: Graph, ptr: cython.pointer[lib.AVFilterLink]) -> FilterLink:
     link: FilterLink = FilterLink(_cinit_sentinel)
-    link.graph = graph
+    link._graph = weakref.ref(graph)
     link.ptr = ptr
     return link
 


### PR DESCRIPTION
This breaks a reference cycle similar to what has been done for `FilterContext` in #1439.

```python
import gc
from av.filter import Graph


def test_graph_leak():
    graph = Graph()
    src = graph.add("testsrc")
    sink = graph.add("buffersink")
    src.link_to(sink)
    src.outputs[0].link


test_graph_leak()

gc.set_debug(gc.DEBUG_SAVEALL)
collected = gc.collect()
print(f"Collected {collected} objects")
for obj in gc.garbage:
    print(f"  - {type(obj).__name__}")
```

**main:**
```
Collected 14 objects
  - Graph
  - dict
  - dict
  - dict
  - Filter
  - FilterContext
  - ReferenceType
  - list
  - Filter
  - FilterContext
  - list
  - FilterContextPad
  - tuple
  - FilterLink
```

**This PR:**
```
Collected 6 objects
  - Filter
  - FilterContext
  - ReferenceType
  - FilterContextPad
  - tuple
  - FilterLink
```

Found while looking into #2282