### PR TITLE
Fix memory leak when setting opaque on Frame

### DIFF
--- a/av/opaque.py
+++ b/av/opaque.py
@@ -15,6 +15,7 @@ def key_free(opaque: cython.p_void, data: u8ptr) -> cython.void:
     name: cython.p_char = cython.cast(cython.p_char, data)
     with cython.gil:
         opaque_container.pop(name)
+    lib.av_free(data)
 
 
 @cython.final


### PR DESCRIPTION
```python
import resource
import av

def get_rss():
    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss

print(f"Base RSS memory: {get_rss():,} bytes")

print("Running 1,000,000 iterations of setting .opaque...")
for i in range(1_000_000):
    frame = av.VideoFrame(16, 16, "yuv420p")
    frame.opaque = i  # This triggers the av_malloc in opaque.py
    del frame

print(f"Final RSS memory: {get_rss():,} bytes")
```

**main:**
```
Base RSS memory: 42,450,944 bytes
Running 1,000,000 iterations of setting .opaque...
Final RSS memory: 57,950,208 bytes
```

**This PR:**
```
Base RSS memory: 42,287,104 bytes
Running 1,000,000 iterations of setting .opaque...
Final RSS memory: 42,287,104 bytes
```