### PR TITLE
Fix #2264 (Re-revised)

### DIFF
--- a/av/device.py
+++ b/av/device.py
@@ -59,8 +59,10 @@ def _build_device_list(device_list: cython.pointer[lib.AVDeviceInfoList]) -> lis
 
         devices.append(
             DeviceInfo(
-                name=device_info.device_name if device_info.device_name else "",
-                description=device_info.device_description
+                name=cython.cast(bytes, device_info.device_name).decode()
+                if device_info.device_name
+                else "",
+                description=cython.cast(bytes, device_info.device_description).decode()
                 if device_info.device_description
                 else "",
                 is_default=(i == device_list.default_device),


### PR DESCRIPTION
device_name/device_description may contains UTF-8.
In commit 2474f35, directly cast to `str` but this assumes ASCII,
so it will raises exception if UTF-8 is included.

In this commit, casts to `bytes` and then decodes UTF8.