### PR TITLE
Fix unsound pointer-to-long casts that truncate on LLP64

### DIFF
--- a/av/audio/frame.py
+++ b/av/audio/frame.py
@@ -78,7 +78,7 @@ class AudioFrame(Frame):
                     self.layout.nb_channels,
                     cython.cast(lib.AVSampleFormat, self.ptr.format),
                     self._buffer,
-                    self._buffer_size,
+                    cython.cast(cython.int, self._buffer_size),
                     align,
                 )
             )

--- a/av/codec/context.py
+++ b/av/codec/context.py
@@ -207,7 +207,7 @@ class CodecContext:
             if not self.ptr.extradata:
                 raise MemoryError("Cannot allocate extradata")
             memcpy(self.ptr.extradata, source.ptr, source.length)
-            self.ptr.extradata_size = source.length
+            self.ptr.extradata_size = cython.cast(cython.int, source.length)
 
     @property
     def extradata_size(self):
@@ -294,7 +294,9 @@ class CodecContext:
         source: ByteSource = bytesource(raw_input, allow_none=True)
 
         in_data: cython.p_uchar = source.ptr if source is not None else cython.NULL
-        in_size: cython.int = source.length if source is not None else 0
+        in_size: cython.int = (
+            cython.cast(cython.int, source.length) if source is not None else 0
+        )
 
         out_data: cython.p_uchar
         out_size: cython.int
@@ -642,7 +644,7 @@ class CodecContext:
         return self.ptr.bit_rate if self.ptr.bit_rate > 0 else None
 
     @bit_rate.setter
-    def bit_rate(self, value: cython.int):
+    def bit_rate(self, value: cython.longlong):
         self.ptr.bit_rate = value
 
     @property

--- a/av/container/core.py
+++ b/av/container/core.py
@@ -487,7 +487,7 @@ class Container:
                 )
             ch_array[i] = ch
 
-        self.ptr.nb_chapters = count
+        self.ptr.nb_chapters = cython.cast(cython.uint, count)
         self.ptr.chapters = ch_array
 
 

--- a/av/container/output.py
+++ b/av/container/output.py
@@ -383,7 +383,7 @@ class OutputContainer(Container):
                 buf[i] = data[i]
             buf[payload_size] = 0
             stream.codecpar.extradata = cython.cast(cython.p_uchar, buf)
-            stream.codecpar.extradata_size = payload_size
+            stream.codecpar.extradata_size = cython.cast(cython.int, payload_size)
 
         # Wrap as user-land stream.
         meta_ptr = cython.address(stream.metadata)

--- a/av/container/pyio.pxd
+++ b/av/container/pyio.pxd
@@ -20,5 +20,5 @@ cdef class PyIOFile:
     # Custom IO for above.
     cdef lib.AVIOContext *iocontext
     cdef unsigned char *buffer
-    cdef long pos
+    cdef int64_t pos
     cdef bint pos_is_valid

--- a/av/container/pyio.py
+++ b/av/container/pyio.py
@@ -109,7 +109,7 @@ def pyio_read_gil(opaque: cython.p_void, buf: Buf, buf_size: cython.int) -> cyth
         self.pos += len(res)
         if not res:
             return lib.AVERROR_EOF
-        return len(res)
+        return cython.cast(cython.int, len(res))
     except Exception:
         return stash_exception()
 

--- a/av/filter/graph.pxd
+++ b/av/filter/graph.pxd
@@ -18,7 +18,7 @@ cdef class Graph:
     cdef _register_context(self, FilterContext)
     cdef _auto_register(self)
     cdef int _nb_filters_seen
-    cdef dict[long, FilterContext] _context_by_ptr
+    cdef dict[size_t, FilterContext] _context_by_ptr
     cdef dict[str, list[FilterContext]] _context_by_type
     cdef list[FilterContext] _video_sources
     cdef list[FilterContext] _audio_sources

--- a/av/filter/graph.py
+++ b/av/filter/graph.py
@@ -111,7 +111,7 @@ class Graph:
     @cython.cfunc
     def _register_context(self, ctx: FilterContext):
         name: str = ctx.filter.ptr.name
-        self._context_by_ptr[cython.cast(cython.long, ctx.ptr)] = ctx
+        self._context_by_ptr[cython.cast(cython.size_t, ctx.ptr)] = ctx
         self._context_by_type.setdefault(name, []).append(ctx)
         if name == "buffer":
             self._video_sources.append(ctx)
@@ -128,7 +128,7 @@ class Graph:
         # point we don't expose that in the API, so we should be okay...
         for i in range(self._nb_filters_seen, self.ptr.nb_filters):
             c_ctx = self.ptr.filters[i]
-            if cython.cast(cython.long, c_ctx) in self._context_by_ptr:
+            if cython.cast(cython.size_t, c_ctx) in self._context_by_ptr:
                 continue
             filter_ = wrap_filter(c_ctx.filter)
             py_ctx = wrap_filter_context(self, filter_, c_ctx)

--- a/av/filter/link.py
+++ b/av/filter/link.py
@@ -33,7 +33,7 @@ class FilterLink:
         else:  # nobreak
             raise RuntimeError("could not find link in context")
         graph: Graph = self.graph
-        ctx = graph._context_by_ptr[cython.cast(cython.long, cctx)]
+        ctx = graph._context_by_ptr[cython.cast(cython.size_t, cctx)]
         self._input = ctx.outputs[i]
         return self._input
 
@@ -50,7 +50,7 @@ class FilterLink:
             raise RuntimeError("could not find link in context")
         try:
             graph: Graph = self.graph
-            ctx = graph._context_by_ptr[cython.cast(cython.long, cctx)]
+            ctx = graph._context_by_ptr[cython.cast(cython.size_t, cctx)]
         except KeyError:
             raise RuntimeError(
                 "could not find context in graph", (cctx.name, cctx.filter.name)

--- a/av/opaque.py
+++ b/av/opaque.py
@@ -27,7 +27,7 @@ class OpaqueContainer:
     @cython.cfunc
     def add(self, v: object) -> cython.pointer[lib.AVBufferRef]:
         # Use object's memory address as key
-        key: uintptr_t = cython.cast(cython.longlong, id(v))
+        key: uintptr_t = cython.cast(uintptr_t, id(v))
         self._objects[key] = v
 
         data: u8ptr = cython.cast(u8ptr, lib.av_malloc(sizeof(uintptr_t)))

--- a/av/packet.py
+++ b/av/packet.py
@@ -237,7 +237,7 @@ class Packet(Buffer):
         if isinstance(input, int):
             size = input
             if size:
-                err_check(lib.av_new_packet(self.ptr, size))
+                err_check(lib.av_new_packet(self.ptr, cython.cast(cython.int, size)))
         else:
             source = bytesource(input)
             size = source.length
@@ -256,7 +256,7 @@ class Packet(Buffer):
                     raise MemoryError("Could not allocate AVBufferRef")
                 self.ptr.buf = buf
                 self.ptr.data = source.ptr
-                self.ptr.size = size
+                self.ptr.size = cython.cast(cython.int, size)
 
     def __repr__(self):
         stream = self._stream.index if self._stream else 0

--- a/av/sidedata/sidedata.py
+++ b/av/sidedata/sidedata.py
@@ -109,7 +109,7 @@ class _SideDataContainer:
         self._by_index: list = []
         self._by_type: dict = {}
 
-        i: cython.Py_ssize_t
+        i: cython.int
         data: SideData
 
         for i in range(self.frame.ptr.nb_side_data):

--- a/av/subtitles/codeccontext.py
+++ b/av/subtitles/codeccontext.py
@@ -44,7 +44,7 @@ class SubtitleCodecContext(CodecContext):
             if not self.ptr.subtitle_header:
                 raise MemoryError("Cannot allocate subtitle_header")
             memcpy(self.ptr.subtitle_header, source.ptr, source.length)
-            self.ptr.subtitle_header_size = source.length
+            self.ptr.subtitle_header_size = cython.cast(cython.int, source.length)
         self.subtitle_header_set = True
 
     def __dealloc__(self) -> None:

--- a/av/video/format.py
+++ b/av/video/format.py
@@ -143,7 +143,7 @@ class VideoFormat:
 @cython.final
 @cython.cclass
 class VideoFormatComponent:
-    def __cinit__(self, format: VideoFormat, index: cython.size_t):
+    def __cinit__(self, format: VideoFormat, index: cython.uint):
         self.format = format
         self.index = index
         self.ptr = cython.address(format.ptr.comp[index])

--- a/include/avcodec.pxd
+++ b/include/avcodec.pxd
@@ -338,7 +338,7 @@ cdef extern from "libavcodec/avcodec.h" nogil:
     cdef struct AVFrameSideData:
         AVFrameSideDataType type
         uint8_t *data
-        int size
+        size_t size
         AVDictionary *metadata
 
     # See: http://ffmpeg.org/doxygen/trunk/structAVFrame.html

--- a/include/avcodec.pxd
+++ b/include/avcodec.pxd
@@ -232,7 +232,7 @@ cdef extern from "libavcodec/avcodec.h" nogil:
 
         void* opaque
 
-        int bit_rate
+        int64_t bit_rate
         int flags
         int flags2
         uint8_t *extradata
@@ -269,8 +269,8 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         int qmin
         int qmax
         int rc_buffer_size
-        int rc_max_rate
-        int rc_min_rate
+        int64_t rc_max_rate
+        int64_t rc_min_rate
 
         AVHWAccel *hwaccel
         AVBufferRef *hw_device_ctx

--- a/include/avformat.pxd
+++ b/include/avformat.pxd
@@ -38,7 +38,7 @@ cdef extern from "libavformat/avformat.h" nogil:
         AVRational sample_aspect_ratio
 
     cdef struct AVChapter:
-        int id
+        int64_t id
         int64_t start
         int64_t end
         AVRational time_base

--- a/include/avformat.pxd
+++ b/include/avformat.pxd
@@ -154,7 +154,7 @@ cdef extern from "libavformat/avformat.h" nogil:
         char filename
         int64_t start_time
         int64_t duration
-        int bit_rate
+        int64_t bit_rate
         int flags
         AVCodecID audio_codec_id
         AVCodecID video_codec_id


### PR DESCRIPTION
Casting AVFilterContext* to C long truncated the high 32 bits on LLP64 platforms (64-bit Windows), so distinct contexts could collide on the same _context_by_ptr key. Key on size_t instead, which is pointer-width everywhere. Also route object addresses through uintptr_t rather than signed long long in OpaqueContainer.add.