### PR TITLE
Return None for unset video codec pix_fmt

### DIFF
--- a/av/video/codeccontext.py
+++ b/av/video/codeccontext.py
@@ -245,6 +245,8 @@ class VideoCodecContext(CodecContext):
         desc: cython.pointer[cython.const[lib.AVPixFmtDescriptor]] = (
             lib.av_pix_fmt_desc_get(cython.cast(lib.AVPixelFormat, self.ptr.pix_fmt))
         )
+        if desc == cython.NULL:
+            return None
         return cython.cast(str, desc.name)
 
     @pix_fmt.setter

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -150,6 +150,8 @@ class TestCodecContext(TestCase):
     def test_encoder_pix_fmt(self) -> None:
         ctx = av.codec.Codec("h264", "w").create("video")
 
+        assert ctx.pix_fmt is None
+
         # valid format
         ctx.pix_fmt = "yuv420p"
         assert ctx.pix_fmt == "yuv420p"


### PR DESCRIPTION
Fixes a segfault when reading `VideoCodecContext.pix_fmt` before a video encoder has a pixel format configured.

Minimal repro:

```python
import av

ctx = av.CodecContext.create("mpeg4", "w")
# ctx.<press Tab> segfaults on current main / 17.1.0
```