### PR TITLE
Expose `AVCodecContext.field_order`

### DIFF
--- a/av/video/codeccontext.py
+++ b/av/video/codeccontext.py
@@ -435,6 +435,19 @@ class VideoCodecContext(CodecContext):
         self.ptr.colorspace = value
 
     @property
+    def field_order(self):
+        """The video field order as FFmpeg's raw integer value.
+
+        Wraps :ffmpeg:`AVCodecContext.field_order`.
+
+        """
+        return self.ptr.field_order
+
+    @field_order.setter
+    def field_order(self, value: cython.int):
+        self.ptr.field_order = value
+
+    @property
     def max_b_frames(self):
         """
         The maximum run of consecutive B frames when encoding a video.

--- a/av/video/codeccontext.pyi
+++ b/av/video/codeccontext.pyi
@@ -32,6 +32,7 @@ class VideoCodecContext(CodecContext):
     color_primaries: int
     color_trc: int
     colorspace: int
+    field_order: int
     qmin: int
     qmax: int
     type: Literal["video"]

--- a/include/avcodec.pxd
+++ b/include/avcodec.pxd
@@ -252,6 +252,7 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         AVColorTransferCharacteristic color_trc
         AVColorSpace colorspace
         AVColorRange color_range
+        int field_order
 
         int has_b_frames
         AVPixelFormat (*get_format)(AVCodecContext *s, const AVPixelFormat *fmt)

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -83,6 +83,14 @@ class TestCodecContext(TestCase):
         ctx.level = 5
         assert ctx.level == 5
 
+    def test_field_order(self):
+        with av.open(fate_suite("h264/interlaced_crop.mp4")) as container:
+            assert container.streams.video[0].codec_context.field_order == 2
+
+        ctx = Codec("mpeg4", "w").create()
+        ctx.field_order = 1
+        assert ctx.field_order == 1
+
     def test_skip_frame_default(self):
         ctx = Codec("png", "w").create()
         assert ctx.skip_frame == "DEFAULT"


### PR DESCRIPTION
Closes #2347.