### PR TITLE
Fix segfault: keep Graph alive from held filter ctx

### DIFF
--- a/av/container/output.py
+++ b/av/container/output.py
@@ -282,6 +282,8 @@ class OutputContainer(Container):
         :param \\**kwargs: Set attributes for the stream.
         :rtype: The new :class:`~av.stream.Stream`.
         """
+        template.container._assert_open()
+
         if opaque is None:
             opaque = template.type != "video"
 

--- a/av/filter/context.py
+++ b/av/filter/context.py
@@ -113,6 +113,11 @@ class FilterContext:
     def push(self, frame: Frame | None):
         res: cython.int
 
+        # av_buffersrc_write_frame() dereferences graph internals that only
+        # exist after configuration; pushing first would segfault.
+        if self._kind == _KIND_SOURCE or frame is None:
+            self._graph.configure()
+
         if frame is None:
             with cython.nogil:
                 res = lib.av_buffersrc_write_frame(self.ptr, cython.NULL)

--- a/av/filter/context.py
+++ b/av/filter/context.py
@@ -1,5 +1,3 @@
-import weakref
-
 import cython
 import cython.cimports.libav as lib
 from cython.cimports.av.audio.frame import alloc_audio_frame
@@ -23,7 +21,7 @@ def wrap_filter_context(
     graph: Graph, filter: Filter, ptr: cython.pointer[lib.AVFilterContext]
 ) -> FilterContext:
     self: FilterContext = FilterContext(_cinit_sentinel)
-    self._graph = weakref.ref(graph)
+    self._graph = graph
     self.filter = filter
     self.ptr = ptr
 
@@ -110,10 +108,7 @@ class FilterContext:
 
     @property
     def graph(self):
-        if graph := self._graph():
-            return graph
-        else:
-            raise RuntimeError("graph is unallocated")
+        return self._graph
 
     def push(self, frame: Frame | None):
         res: cython.int

--- a/av/filter/graph.pxd
+++ b/av/filter/graph.pxd
@@ -20,5 +20,3 @@ cdef class Graph:
     cdef int _nb_filters_seen
     cdef dict[size_t, FilterContext] _context_by_ptr
     cdef dict[str, list[FilterContext]] _context_by_type
-    cdef list[FilterContext] _video_sources
-    cdef list[FilterContext] _audio_sources

--- a/av/filter/graph.pxd
+++ b/av/filter/graph.pxd
@@ -4,19 +4,18 @@ from av.filter.context cimport FilterContext
 
 
 cdef class Graph:
+    # Fields are laid out in declaration order: pointers first, then the two
+    # ints paired up, so there are no padding holes between them.
     cdef object __weakref__
-
     cdef lib.AVFilterGraph *ptr
-
-    cdef readonly bint configured
-    cpdef configure(self, bint auto_buffer=*, bint force=*)
-
     cdef dict _name_counts
-    cdef str _get_unique_name(self, str name)
-    cdef list[FilterContext] _get_context_by_type(self, str type)
-
-    cdef void _register_context(self, FilterContext)
-    cdef void _auto_register(self)
-    cdef int _nb_filters_seen
     cdef dict[size_t, FilterContext] _context_by_ptr
     cdef dict[str, list[FilterContext]] _context_by_type
+    cdef readonly bint configured
+    cdef int _nb_filters_seen
+
+    cpdef configure(self, bint auto_buffer=*, bint force=*)
+    cdef str _get_unique_name(self, str name)
+    cdef list[FilterContext] _get_context_by_type(self, str type)
+    cdef void _register_context(self, FilterContext)
+    cdef void _auto_register(self)

--- a/av/filter/graph.py
+++ b/av/filter/graph.py
@@ -22,8 +22,6 @@ class Graph:
         self._nb_filters_seen = 0
         self._context_by_ptr = {}
         self._context_by_type = {}
-        self._video_sources = []
-        self._audio_sources = []
 
     def __dealloc__(self):
         if self.ptr:
@@ -113,10 +111,6 @@ class Graph:
         name: str = ctx.filter.ptr.name
         self._context_by_ptr[cython.cast(cython.size_t, ctx.ptr)] = ctx
         self._context_by_type.setdefault(name, []).append(ctx)
-        if name == "buffer":
-            self._video_sources.append(ctx)
-        elif name == "abuffer":
-            self._audio_sources.append(ctx)
 
     @cython.cfunc
     def _auto_register(self) -> cython.void:
@@ -250,11 +244,13 @@ class Graph:
             every buffer source matching the frame's type.
         """
         if frame is None:
-            contexts = self._video_sources + self._audio_sources
+            contexts = self._get_context_by_type("buffer") + self._get_context_by_type(
+                "abuffer"
+            )
         elif isinstance(frame, VideoFrame):
-            contexts = self._video_sources
+            contexts = self._get_context_by_type("buffer")
         elif isinstance(frame, AudioFrame):
-            contexts = self._audio_sources
+            contexts = self._get_context_by_type("abuffer")
         else:
             raise ValueError(
                 f"can only AudioFrame, VideoFrame or None; got {type(frame)}"
@@ -273,7 +269,7 @@ class Graph:
 
     def vpush(self, frame: VideoFrame | None, at: cython.int = -1):
         """Like :meth:`push`, but only for :class:`.VideoFrame`."""
-        contexts = self._video_sources
+        contexts = self._get_context_by_type("buffer")
         if at >= 0:
             if at >= len(contexts):
                 raise IndexError(

--- a/av/filter/link.py
+++ b/av/filter/link.py
@@ -89,6 +89,13 @@ class FilterPad:
     def name(self):
         return lib.avfilter_pad_get_name(self.base_ptr, self.index)
 
+    @property
+    def type(self):
+        media_type = lib.av_get_media_type_string(
+            lib.avfilter_pad_get_type(self.base_ptr, self.index)
+        )
+        return "unknown" if media_type == cython.NULL else media_type
+
 
 @cython.final
 @cython.cclass


### PR DESCRIPTION
A FilterContext held a weakref to its Graph, so dropping the Graph freed the underlying AVFilterContext while the context was still held. Using it (push/link_to/process_command) then dereferenced freed memory. Make `_graph` a strong ref; the Graph<->context cycle is collected by gc.