### PR TITLE
Use a single GIL for logging

### DIFF
--- a/av/logging.py
+++ b/av/logging.py
@@ -331,25 +331,25 @@ def log_callback(
     if not inited:
         return
 
+    message: cython.char[1024]
+
     with cython.gil:
         if level > level_threshold and level != lib.AV_LOG_ERROR:
             return
 
-    # Format the message.
-    message: cython.char[1024]
-    vsnprintf(message, 1023, format, args)
+        # Format the message.
+        vsnprintf(message, 1023, format, args)
 
-    # Get the name.
-    name: cython.p_const_char = cython.NULL
-    cls: cython.pointer[lib.AVClass] = (
-        cython.cast(cython.pointer[cython.pointer[lib.AVClass]], ptr)[0]
-        if ptr
-        else cython.NULL
-    )
-    if cls and cls.item_name:
-        name = cls.item_name(ptr)
+        # Get the name.
+        name: cython.p_const_char = cython.NULL
+        cls: cython.pointer[lib.AVClass] = (
+            cython.cast(cython.pointer[cython.pointer[lib.AVClass]], ptr)[0]
+            if ptr
+            else cython.NULL
+        )
+        if cls and cls.item_name:
+            name = cls.item_name(ptr)
 
-    with cython.gil:
         try:
             log_callback_gil(level, name, message)
         except Exception:


### PR DESCRIPTION
I keep this one around for a while trying to decide if it was worth merging or not, because I worked around the issue in another way, but I think it's worth keeping. Basically, the concept is that if separate threads both log at the same time, then releasing the GIL for that copy can cause issues, so just keep it the whole time. I didn't do any benchmarks to see what the impact was, but I'm guessing that it's pretty minor for most users since they don't log much and releasing the GIL and then re-grabbing it has a cost of its own.

Looks like it's out of date with some changes you've made recently, so if you do want to keep this, then let me know and I'll rebase or feel free to pull it in or do it yourself.

And here's a repro that I tested the change with:
[repro_pyav_logging_segfault.py](https://github.com/user-attachments/files/31441786/repro_pyav_logging_segfault.py)