### PR TITLE
use `uv` tool for PyAV

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Python
-        uses: actions/setup-python@v6
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
+          activate-environment: true
           python-version: "3.14"
       - name: Linters
         run: make lint
@@ -50,10 +51,10 @@ jobs:
       name: Checkout
 
     - name: Python ${{ matrix.config.python }}
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
+        activate-environment: true
         python-version: ${{ matrix.config.python }}
-        allow-prereleases: true
 
     - name: OS Packages
       run: |
@@ -163,27 +164,22 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - name: Set up host Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Set up host Python 3.14t
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14t"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Install build tooling
         run: |
-          for py in python3.12 python3.14t; do
-            $py -m pip install -U "cython>=3.1.0,<4" "setuptools>=77.0" wheel
-          done
+          uv venv --seed --python 3.12 .venv-3.12
+          uv venv --seed --python 3.14t .venv-3.14t
+          uv pip install --python .venv-3.12/bin/python -U "cython>=3.1.0,<4" "setuptools>=77.0" wheel
+          uv pip install --python .venv-3.14t/bin/python -U "cython>=3.1.0,<4" "setuptools>=77.0" wheel
           # patchelf 0.18 (ubuntu-24.04's system version) corrupts ELF files
           # with large p_align; pin <0.18 for auditwheel to use.
-          python3.12 -m pip install -U ziglang auditwheel 'patchelf<0.18'
+          uv pip install --python .venv-3.12/bin/python -U ziglang auditwheel 'patchelf<0.18'
       - name: Cross-compile armv7l wheels with zig
         env:
-          HOST_PY312: python3.12
-          HOST_PY314T: python3.14t
-          TOOLS_PY: python3.12
+          HOST_PY312: .venv-3.12/bin/python
+          HOST_PY314T: .venv-3.14t/bin/python
+          TOOLS_PY: .venv-3.12/bin/python
         run: bash scripts/build-armv7l-cross.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
+          activate-environment: true
           python-version: "3.14"
       - name: Build source package
         run: |
-          pip install -U cython setuptools
+          uv pip install -U cython setuptools
           python scripts/fetch-vendor.py --config-file scripts/ffmpeg-latest.json /tmp/vendor
           PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig python setup.py sdist
       - name: Upload source package
@@ -42,8 +43,9 @@ jobs:
             arch: ARM64
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
+          activate-environment: true
           python-version: "3.14"
       - name: Set Minimum MacOS Target
         if: runner.os == 'macOS'
@@ -64,10 +66,11 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: INCLUDE=C:\\cibw\\vendor\\include LIB=C:\\cibw\\vendor\\lib PYAV_SKIP_TESTS=unicode_filename
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path C:\cibw\vendor\bin -w {dest_dir} {wheel}
           CIBW_BUILD: "cp312* cp314t*"
+          CIBW_BUILD_FRONTEND: uv
           CIBW_TEST_COMMAND: mv {project}/av {project}/av.disabled && python -m pytest {package}/tests && mv {project}/av.disabled {project}/av
           CIBW_TEST_REQUIRES: pytest numpy
         run: |
-          pip install cibuildwheel delvewheel
+          uv pip install cibuildwheel delvewheel
           cibuildwheel --output-dir dist
         shell: bash
       - name: Upload wheels
@@ -83,27 +86,22 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - name: Set up host Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Set up host Python 3.14t
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14t"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Install build tooling
         run: |
-          for py in python3.12 python3.14t; do
-            $py -m pip install -U "cython>=3.1.0,<4" "setuptools>=77.0" wheel
-          done
+          uv venv --seed --python 3.12 .venv-3.12
+          uv venv --seed --python 3.14t .venv-3.14t
+          uv pip install --python .venv-3.12/bin/python -U "cython>=3.1.0,<4" "setuptools>=77.0" wheel
+          uv pip install --python .venv-3.14t/bin/python -U "cython>=3.1.0,<4" "setuptools>=77.0" wheel
           # patchelf 0.18 (ubuntu-24.04's system version) corrupts ELF files
           # with large p_align; pin <0.18 for auditwheel to use.
-          python3.12 -m pip install -U ziglang auditwheel 'patchelf<0.18'
+          uv pip install --python .venv-3.12/bin/python -U ziglang auditwheel 'patchelf<0.18'
       - name: Cross-compile armv7l wheels with zig
         env:
-          HOST_PY312: python3.12
-          HOST_PY314T: python3.14t
-          TOOLS_PY: python3.12
+          HOST_PY312: .venv-3.12/bin/python
+          HOST_PY314T: .venv-3.14t/bin/python
+          TOOLS_PY: .venv-3.12/bin/python
         run: bash scripts/build-armv7l-cross.sh
       - name: Upload wheels
         uses: actions/upload-artifact@v6

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LDFLAGS ?= ""
 CFLAGS ?= "-O0 -Wno-unreachable-code"
 
 PYAV_PYTHON ?= python
-PYAV_PIP ?= pip
+PYAV_PIP ?= uv pip
 PYTHON := $(PYAV_PYTHON)
 PIP := $(PYAV_PIP)
 
@@ -29,11 +29,11 @@ fate-suite:
 	rsync -vrltLW rsync://fate-suite.ffmpeg.org/fate-suite/ tests/assets/fate-suite/
 
 lint:
-	$(PIP) install -U ruff isort pillow numpy mypy==2.1.0 pytest
+	$(PIP) install --group lint
 	ruff format --check av examples tests setup.py
 	isort --check-only --diff av examples tests
 	mypy av tests
 
 test:
-	$(PIP) install --upgrade cython numpy pillow pytest
+	$(PIP) install --group test
 	$(PYTHON) -m pytest

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 SPHINXOPTS    =
 BUILDDIR      = _build
-PYAV_PIP ?= pip
+PYAV_PIP ?= uv pip
 PIP := $(PYAV_PIP)
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ homepage = "https://pyav.basswood.io"
 profile = "black"
 known_first_party = ["av"]
 skip = ["av/__init__.py"]
+
+[tool.uv]
+prerelease = "allow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,7 @@ skip = ["av/__init__.py"]
 
 [tool.uv]
 prerelease = "allow"
+
+[dependency-groups]
+test = ["cython>=3.3.0,<4", "numpy", "pillow", "pytest"]
+lint = ["ruff", "isort", "mypy==2.1.0", {include-group = "test"}]

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -43,7 +43,8 @@ if [[ "$PYAV_PYTHON" == *pypy* ]]; then
 fi
 
 export PYAV_PYTHON
-export PYAV_PIP="${PYAV_PIP-$PYAV_PYTHON -m pip}"
+export UV_PYTHON="$PYAV_PYTHON"
+export PYAV_PIP="${PYAV_PIP-uv pip}"
 
 if [[ "$GITHUB_ACTION" ]]; then
 
@@ -64,8 +65,7 @@ print("{}{}.{}".format(platform.python_implementation().lower(), *sys.version_in
 
     if [[ ! -e "$PYAV_VENV/bin/python" ]]; then
         mkdir -p "$PYAV_VENV"
-        virtualenv -p "$PYAV_PYTHON" "$PYAV_VENV"
-        "$PYAV_VENV/bin/pip" install --upgrade pip setuptools
+        uv venv -p "$PYAV_PYTHON" "$PYAV_VENV"
     fi
 
     if [[ -e "$PYAV_VENV/bin/activate" ]]; then


### PR DESCRIPTION
[uv](https://docs.astral.sh/uv/) is an all-in-one Python management tool written in Rust, which provides equivalents for `pip`, `venv` management, and so on. It's also [much faster](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md) in general and supports more architectures (notably, riscv64) with [setup-uv](https://github.com/astral-sh/setup-uv). This patch series reworks the PyAV repository to use `uv` everywhere, with the hope that it will simplify further development.

This is being done on behalf of [RISE](https://riseproject.dev/) as a precursor to adding riscv64 support for PyAV using RISE's [RISC-V Runners](https://riscv-runners.riseproject.dev/). Simpler riscv64 support was recently added in [pyav-ffmpeg](https://github.com/PyAV-Org/pyav-ffmpeg/pull/214), although in that case it was a cross-build change. We are using the [RISC-V Wheels](https://stanfromireland.github.io/riscv-wheels/) dashboard to track Python compatibility for riscv64, and this package is one of many on the list we want to help add support for.

I've tested this on my fork: https://github.com/threexc/PyAV/pull/1