### PR TITLE
Add yuv422p to supported_np_pix_fmts

### DIFF
--- a/av/video/format.pyi
+++ b/av/video/format.pyi
@@ -28,3 +28,5 @@ class VideoFormatComponent:
     height: int
 
     def __init__(self, format: VideoFormat, index: int) -> None: ...
+
+names: set[str]

--- a/av/video/frame.py
+++ b/av/video/frame.py
@@ -344,6 +344,7 @@ supported_np_pix_fmts = {
     "rgbf32le",
     "yuv420p",
     "yuv420p10le",
+    "yuv422p",
     "yuv422p10le",
     "yuv444p",
     "yuv444p16be",

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -755,9 +755,30 @@ def test_ndarray_yuv420p10le_zero_size() -> None:
 def test_ndarray_yuv422p() -> None:
     array = numpy.random.randint(0, 256, size=(960, 640), dtype=numpy.uint8)
     frame = VideoFrame.from_ndarray(array, format="yuv422p")
+    assert "yuv422p" in supported_np_pix_fmts
     assert frame.width == 640 and frame.height == 480
     assert frame.format.name == "yuv422p"
     assertNdarraysEqual(frame.to_ndarray(), array)
+
+
+def test_supported_np_pix_fmts_matches_to_ndarray() -> None:
+    # supported_np_pix_fmts is public API describing what to_ndarray() accepts,
+    # so it is checked against to_ndarray() itself rather than against a list
+    # that would have to be kept in step with it by hand.
+    converts = set()
+    for name in av.video.format.names:
+        try:
+            VideoFrame(32, 16, name).to_ndarray()
+        except Exception:
+            continue
+        converts.add(name)
+
+    assert converts - supported_np_pix_fmts == set()
+
+    # Names that av.video.format.names does not carry are aliases, so the
+    # advertised set is checked directly rather than through the sweep.
+    for name in supported_np_pix_fmts:
+        VideoFrame(32, 16, name).to_ndarray()
 
 
 def test_ndarray_yuv420p_align() -> None:


### PR DESCRIPTION
`supported_np_pix_fmts` is described in the source as "`pix_fmt`s supported by `Frame.to_ndarray()` and `Frame.from_ndarray()`", and it is exported in `frame.pyi`, but it is missing `yuv422p`. `yuv422p` has worked in both directions since #2054, whose patch never mentions the set — #1766 added the set in Feb 2025, #2054 added the format in Dec 2025.

Sweeping all 267 names in `av.video.format.names` plus the advertised set (to cover aliases such as `gray8`, which is not in `names`) and calling `to_ndarray()` on a 32x16 frame: 86 formats convert, the set lists 85, and `yuv422p` is the only difference in either direction. On PyPI `av` 18.1.0 it also round-trips byte-identically through `from_ndarray`.

Nothing caught it because every check on the set is `assert format in supported_np_pix_fmts` inside `tests/test_videoframe.py` — the assertion iterates the set it is validating, so an omission cannot fail it. `test_ndarray_yuv422p`, added by #2054, is one of the tests without even that line. So rather than adding another such assertion alone, the new test derives the expected set from `to_ndarray()` itself. It needs `names` in `av/video/format.pyi`, which was missing (`mypy` flags it), so that line is here too.

Mutants, each rebuilt and the marker checked in the built module rather than the source:

* revert the set entry: `test_ndarray_yuv422p` and the new test both fail
* the opposite remedy, dropping `yuv422p` from `to_ndarray` so the set is right: the new test passes and `test_ndarray_yuv422p` fails, which is what pins the direction
* advertise a format that does not convert (`yuv411p`): only the new test fails, so the second loop in it is doing work

macOS arm64, Python 3.12, FFmpeg 8.1.2: `pytest tests` gives 531 passed / 30 skipped / 55 subtests before and 532 / 30 / 55 after, both legs in the same session with the built module checked each time. `ruff format --check`, `isort --check-only` and `mypy av tests` are clean apart from the pre-existing `av/video/plane.pyi:1 types.CapsuleType` error, which is identical on a clean tree here. No `CHANGELOG.rst` entry, following #2054.

AI assistance: the diff, the test and this description were drafted by Claude Opus 5 working as a coding agent in this repository.
