### PR TITLE
PyAV: add riscv64 build support, use pyav-ffmpeg artifacts in smoke.yml

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -68,7 +68,7 @@ jobs:
         case ${{ matrix.config.os }} in
           ubuntu-24.04)
             sudo apt-get update
-            sudo apt-get install \
+            sudo apt-get install -y \
               autoconf \
               automake \
               build-essential \
@@ -79,7 +79,7 @@ jobs:
               pkg-config \
               zlib1g-dev
             if [[ "${{ matrix.config.extras }}" ]]; then
-              sudo apt-get install doxygen
+              sudo apt-get install -y doxygen
             fi
             ;;
           macos-14)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,8 @@ jobs:
             arch: arm64
           - os: macos-15-intel
             arch: x86_64
+          - os: ubuntu-24.04-riscv
+            arch: riscv64
           - os: ubuntu-24.04-arm
             arch: aarch64
           - os: ubuntu-24.04
@@ -61,7 +63,10 @@ jobs:
           CIBW_BEFORE_BUILD: python scripts/fetch-vendor.py --config-file scripts/ffmpeg-latest.json /tmp/vendor
           CIBW_BEFORE_BUILD_MACOS: python scripts/fetch-vendor.py --config-file scripts/ffmpeg-latest.json /tmp/vendor
           CIBW_BEFORE_BUILD_WINDOWS: python scripts\fetch-vendor.py --config-file scripts\ffmpeg-latest.json C:\cibw\vendor
-          CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH=/tmp/vendor/lib:$LD_LIBRARY_PATH PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig
+          # riscv64 wheels (e.g. numpy, for CIBW_TEST_REQUIRES) are often missing on
+          # PyPI; RISE mirrors prebuilt wheels for it. unsafe-best-match is needed so
+          # uv still falls back to PyPI for packages/versions RISE doesn't carry.
+          CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH=/tmp/vendor/lib:$LD_LIBRARY_PATH PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig${{ matrix.arch == 'riscv64' && ' UV_INDEX=https://pypi.riseproject.dev/simple/ UV_INDEX_STRATEGY=unsafe-best-match' || '' }}
           CIBW_ENVIRONMENT_MACOS: PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig LDFLAGS=-headerpad_max_install_names
           CIBW_ENVIRONMENT_WINDOWS: INCLUDE=C:\\cibw\\vendor\\include LIB=C:\\cibw\\vendor\\lib PYAV_SKIP_TESTS=unicode_filename
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path C:\cibw\vendor\bin -w {dest_dir} {wheel}


### PR DESCRIPTION
Make use of RISE's Native RISC-V Runners to build PyAV for riscv64. This requires enabling them for the repository as a GitHub Application. More info regarding enabling them is available here: https://riscv-runners.riseproject.dev/

To get the `smoke.yml` workflow to succeed, I've reworked it to use pyav-ffmpeg artifacts like the `tests.yml` workflow does, except that the `armv7l` job still follows the existing approach. While working through this, I encountered a bug specific to the RISC-V Runners (`riscv64gc` profile), where I hit an illegal instruction/core dump issue that seems to be related to: https://www.mail-archive.com/ffmpeg-trac@avcodec.org/msg69006.html . Using the pyav-ffmpeg artifacts circumvented this issue, which is why it was implemented that way. This is a temporary workaround - in the future, the RISC-V Runners will support a more expansive profile. If using pyav-ffmpeg artifacts in the `smoke.yaml` workflow is undesirable, I can revisit it and maybe adjust compiler flags instead.

I tried a test run on my fork. You can review the results here: https://github.com/threexc/PyAV/pull/2

This is being done on behalf of [RISE](https://riseproject.dev/), using the [RISC-V Wheels](https://stanfromireland.github.io/riscv-wheels/) dashboard to track upstream support for the Python ecosystem.

